### PR TITLE
remove packer-generated key

### DIFF
--- a/packer/socorro_base.json
+++ b/packer/socorro_base.json
@@ -27,6 +27,12 @@
                 "puppet/modules"
             ],
             "prevent_sudo": "true"
+        },
+        {
+            "type": "shell",
+            "inline": [
+                "rm /root/.ssh/authorized_keys"
+            ]
         }
     ]
 }


### PR DESCRIPTION
As noted [here](https://github.com/mitchellh/packer/issues/185), there is a particular edge case involving Packer and the AWS CentOS 6 AMIs: briefly, Packer will generate and use a temporary, random pubkey for provisioning the AMI, which then needs to be removed so that the *explicitly* defined pubkey takes its place on the next boot.

This is a work-around while we wait for [bug 1124623](https://bugzilla.mozilla.org/show_bug.cgi?id=1124623) to get sorted out; interestingly, this PR actually solves one possible scenario of that bug...

@rhelmer `r?`