### PR TITLE
fix bug 1132398; add buildbox profile & support for alt profiles in general

### DIFF
--- a/packer/puppet/manifests/default.pp
+++ b/packer/puppet/manifests/default.pp
@@ -3,5 +3,12 @@ Exec {
 }
 
 node default {
-  include socorro::generic
+  case $::packer_profile {
+    'base': { include socorro::base }
+    'buildbox': { include socorro::buildbox }
+    default: {
+      err("'${::packer_profile}' is not a valid Packer profile label.")
+      fail('Invalid packer_profile.')
+    }
+  }
 }

--- a/packer/puppet/modules/socorro/manifests/base.pp
+++ b/packer/puppet/modules/socorro/manifests/base.pp
@@ -1,0 +1,109 @@
+# Set up basic Socorro requirements.
+class socorro::base {
+
+  include socorro
+
+  service {
+    'httpd':
+      ensure  => stopped,
+      enable  => false,
+      require => Package['httpd'];
+
+    'postgresql-9.3':
+      ensure  => stopped,
+      enable  => false,
+      require => [
+        Package['postgresql93-server'],
+        File['pg_hba.conf'],
+      ];
+
+    'elasticsearch':
+      ensure  => stopped,
+      enable  => false,
+      require => Package['elasticsearch'];
+
+    'rabbitmq-server':
+      ensure  => stopped,
+      enable  => false,
+      require => Package['rabbitmq-server'];
+  }
+
+  yumrepo {
+    'elasticsearch':
+      baseurl => 'http://packages.elasticsearch.org/elasticsearch/1.4/centos',
+      gpgkey  => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch';
+    'PGDG':
+      baseurl => 'http://yum.postgresql.org/9.3/redhat/rhel-$releasever-$basearch',
+      gpgkey  => 'http://yum.postgresql.org/RPM-GPG-KEY-PGDG';
+  }
+
+  Yumrepo['elasticsearch', 'PGDG'] {
+    enabled  => 1,
+    gpgcheck => 1
+  }
+
+  package {
+    [
+      'httpd',
+      'java-1.7.0-openjdk',
+      'mod_wsgi',
+      'rabbitmq-server',
+      'supervisor',
+      'unzip'
+    ]:
+    ensure  => latest,
+    require => Package['epel-release', 'yum-plugin-fastestmirror']
+  }
+
+  package {
+    [
+      'postgresql93-contrib',
+      'postgresql93-devel',
+      'postgresql93-plperl',
+      'postgresql93-server'
+    ]:
+    ensure  => latest,
+    require => [
+      Yumrepo['PGDG'],
+      Package['ca-certificates']
+    ]
+  }
+
+  package {
+    'elasticsearch':
+      ensure  => latest,
+      require => [
+        Yumrepo['elasticsearch'],
+        Package['java-1.7.0-openjdk']
+      ]
+  }
+
+  file {
+    '/etc/socorro':
+      ensure => directory;
+
+    'pg_hba.conf':
+      ensure  => file,
+      path    => '/var/lib/pgsql/9.3/data/pg_hba.conf',
+      source  => 'puppet:///modules/socorro/var_lib_pgsql_9.3_data/pg_hba.conf',
+      owner   => 'postgres',
+      group   => 'postgres',
+      require => Package['postgresql93-server'],
+      notify  => Service['postgresql-9.3'];
+
+    'pgsql.sh':
+      ensure => file,
+      path   => '/etc/profile.d/pgsql.sh',
+      source => 'puppet:///modules/socorro/etc_profile.d/pgsql.sh',
+      owner  => 'root';
+
+    'elasticsearch.yml':
+      ensure  => file,
+      path    => '/etc/elasticsearch/elasticsearch.yml',
+      source  => 'puppet:///modules/socorro/etc_elasticsearch/elasticsearch.yml',
+      owner   => 'root',
+      require => Package['elasticsearch'],
+      notify  => Service['elasticsearch'];
+  }
+
+}

--- a/packer/puppet/modules/socorro/manifests/buildbox.pp
+++ b/packer/puppet/modules/socorro/manifests/buildbox.pp
@@ -1,0 +1,29 @@
+# Box used for building Socorro components.
+class socorro::buildbox {
+
+  # Don't forget to include the common components!
+  include socorro
+
+  package {
+    [
+      'gcc-c++',
+      'git',
+      'java-1.7.0-openjdk',
+      'java-1.7.0-openjdk-devel',
+      'libcurl-devel',
+      'libxml2-devel',
+      'libxslt-devel',
+      'make',
+      'openldap-devel',
+      'python-devel',
+      'rpm-build',
+      'rsync',
+      'ruby-devel',
+      'subversion',
+      'time',
+      'unzip'
+    ]:
+    ensure  => latest,
+    require => Package['epel-release']
+  }
+}

--- a/packer/puppet/modules/socorro/manifests/init.pp
+++ b/packer/puppet/modules/socorro/manifests/init.pp
@@ -1,48 +1,11 @@
-# Set up basic Socorro requirements.
-class socorro::generic {
+# Elements common to all Socorro boxes.
+class socorro {
 
   service {
     'sshd':
       ensure  => running,
       enable  => true,
-      require => File['sshd_config'];
-
-    'httpd':
-      ensure  => stopped,
-      enable  => false,
-      require => Package['httpd'];
-
-    'postgresql-9.3':
-      ensure  => stopped,
-      enable  => false,
-      require => [
-        Package['postgresql93-server'],
-        File['pg_hba.conf'],
-      ];
-
-    'elasticsearch':
-      ensure  => stopped,
-      enable  => false,
-      require => Package['elasticsearch'];
-
-    'rabbitmq-server':
-      ensure  => stopped,
-      enable  => false,
-      require => Package['rabbitmq-server'];
-  }
-
-  yumrepo {
-    'elasticsearch':
-      baseurl => 'http://packages.elasticsearch.org/elasticsearch/1.4/centos',
-      gpgkey  => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch';
-    'PGDG':
-      baseurl => 'http://yum.postgresql.org/9.3/redhat/rhel-$releasever-$basearch',
-      gpgkey  => 'http://yum.postgresql.org/RPM-GPG-KEY-PGDG';
-  }
-
-  Yumrepo['elasticsearch', 'PGDG'] {
-    enabled  => 1,
-    gpgcheck => 1
+      require => File['sshd_config']
   }
 
   package {
@@ -51,64 +14,17 @@ class socorro::generic {
   }
 
   package {
-    'yum-plugin-fastestmirror':
-      ensure  => latest,
-      require => Package['ca-certificates']
-  }
-
-  package {
     [
       'epel-release',
-      'httpd',
-      'java-1.7.0-openjdk',
-      'mod_wsgi',
-      'unzip',
-    ]:
-    ensure  => latest,
-    require => Package['yum-plugin-fastestmirror']
-  }
-
-  package {
-    [
-      'postgresql93-contrib',
-      'postgresql93-devel',
-      'postgresql93-plperl',
-      'postgresql93-server',
+      'yum-plugin-fastestmirror'
     ]:
     ensure  => latest,
     require => [
-      Yumrepo['PGDG'],
       Package['ca-certificates']
     ]
   }
 
-  package {
-    [
-      'rabbitmq-server',
-      'supervisor'
-    ]:
-      ensure  => latest,
-      require => Package['epel-release']
-  }
-
-  package {
-    'elasticsearch':
-      ensure  => latest,
-      require => [
-        Yumrepo['elasticsearch'],
-        Package['java-1.7.0-openjdk']
-      ]
-  }
-
   file {
-    'sshd_config':
-      ensure => file,
-      path   => '/etc/ssh/sshd_config',
-      source => 'puppet:///modules/socorro/etc_ssh/sshd_config',
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644';
-
     'selinux_config':
       ensure => file,
       path   => '/etc/selinux/config',
@@ -117,31 +33,13 @@ class socorro::generic {
       group  => 'root',
       mode   => '0644';
 
-    '/etc/socorro':
-      ensure => directory;
-
-    'pg_hba.conf':
-      ensure  => file,
-      path    => '/var/lib/pgsql/9.3/data/pg_hba.conf',
-      source  => 'puppet:///modules/socorro/var_lib_pgsql_9.3_data/pg_hba.conf',
-      owner   => 'postgres',
-      group   => 'postgres',
-      require => Package['postgresql93-server'],
-      notify  => Service['postgresql-9.3'];
-
-    'pgsql.sh':
+    'sshd_config':
       ensure => file,
-      path   => '/etc/profile.d/pgsql.sh',
-      source => 'puppet:///modules/socorro/etc_profile.d/pgsql.sh',
-      owner  => 'root';
-
-    'elasticsearch.yml':
-      ensure  => file,
-      path    => '/etc/elasticsearch/elasticsearch.yml',
-      source  => 'puppet:///modules/socorro/etc_elasticsearch/elasticsearch.yml',
-      owner   => 'root',
-      require => Package['elasticsearch'],
-      notify  => Service['elasticsearch'];
+      path   => '/etc/ssh/sshd_config',
+      source => 'puppet:///modules/socorro/etc_ssh/sshd_config',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644'
   }
 
 }

--- a/packer/socorro_buildbox.json
+++ b/packer/socorro_buildbox.json
@@ -12,7 +12,7 @@
             "source_ami": "ami-c7d092f7",
             "instance_type": "t2.micro",
             "ssh_username": "centos",
-            "ami_name": "socorro_centos7__{{timestamp}}"
+            "ami_name": "socorro_buildbox__{{timestamp}}"
         }
     ],
     "provisioners": [
@@ -28,7 +28,7 @@
                 "puppet/modules"
             ],
             "facter": {
-                "packer_profile": "base"
+                "packer_profile": "buildbox"
             }
         }
     ]


### PR DESCRIPTION
This PR introduces the idea of alternative Packer profiles, and adds a `buildbox` profile into the mix.

This is more or less just a bunch of Puppet stuff.  There are any number of ways to deal with this - including layers of templates, use of Hiera, and so forth.  I opted to keep it simple, which is fine as long as we don't need to extend this to, like dozens of profiles. :smile: 

Anyway, what we need to do is determine what needs to be installed on the buildbox (I just put some of the stuff from the Vagrant box in there as filler, for now).  This is something we'll need to work on together, @rhelmer . :grapes: 