### PR TITLE
fix bug 1132180; add environment prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 credentials.json
 terraform.tfvars
+terraform.tfstate*
 *.pem
 *.swp
 *.plan

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -10,6 +10,20 @@ process are still being worked on.
 ## Details
 
 Performing a `terraform apply` on this repo will result in a small amount of
-infrastructure being spun up in the `us-west-2` AWS zone.  The AWS access and
-secret keys need to be supplied either as environment variables, or via
-the `terraform.tfvars` file.
+infrastructure being spun up in the `us-west-2` AWS zone.
+
+Three variables have no useful default and must be supplied:
+* `access_key`: The AWS access key.
+* `secret_key`: The AWS secret key.
+* `environment`: A prefix used to designate a logical deployment group.
+
+For testing purposes, it is useful to enable `del_on_term`, which will remove
+EBS volumes once their associated instances are terminated.
+
+You're welcome to deal with this in any number of ways. I suggest putting the
+keys in `terraform.tfvars` and specifying the rest at runtime:
+
+```
+terraform plan -var 'environment=foo' -var 'del_on_term=true' -out=foo.plan
+terraform apply foo.plan
+```

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,7 +1,7 @@
-output "public_addr__webheads__http" {
-    value = "${aws_elb.elb_for_webheads.dns_name}"
+output "public_addr__webhead__http" {
+    value = "${aws_elb.elb_for_webhead.dns_name}"
 }
 
-output "public_addr__collectors__http" {
-    value = "${aws_elb.elb_for_collectors.dns_name}"
+output "public_addr__collector__http" {
+    value = "${aws_elb.elb_for_collector.dns_name}"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,4 @@
+variable "environment" {}
 variable "access_key" {}
 variable "secret_key" {}
 variable "ssh_key_file" {
@@ -23,4 +24,7 @@ variable "base_ami" {
 }
 variable "alt_ssh_port" {
     default = 22123
+}
+variable "del_on_term" {
+    default = "false"
 }


### PR DESCRIPTION
This also adds tags to many of the resources, the net effect being that those resources are easier to identify via the console (which is handy for testing).  Speaking of testing, note the `del_on_term` variable, too.

@rhelmer `r?` :cactus: 