### PR TITLE
use Puppet for role provision

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@ pieces necessary to spin up an instance of Socorro in the cloud.
 
 ## Packer
 
-[Packer](https://www.packer.io) is a tool for creating machine images. We use
+[Packer](https://www.packer.io) is a tool for creating machine images.  We use
 it for generating a generic image suitable for deploying any given Socorro
 role.
+
+## Puppet
+
+[Puppet](https://puppetlabs.com) is a configuration management tool.  We use it
+both for managing the Packer-built images as well as for provisioning nodes.
 
 ## Terraform
 

--- a/puppet/README.md
+++ b/puppet/README.md
@@ -1,0 +1,3 @@
+# Puppet
+
+# Details

--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -4,11 +4,14 @@ Exec {
 
 node default {
   case $::packer_profile {
-    'base': { include socorro::base }
-    'buildbox': { include socorro::buildbox }
-    default: {
-      err("'${::packer_profile}' is not a valid Packer profile label.")
-      fail('Invalid packer_profile.')
-    }
+    'base': { include socorro::packer::base }
+    'buildbox': { include socorro::packer::buildbox }
+    default: {}
+  }
+
+  case $::socorro_role {
+    'consul': { include socorro::role::consul }
+    'symbolapi': { include socorro::role::symbolapi }
+    default: {}
   }
 }

--- a/puppet/modules/socorro/files/etc_consul.d/config.json
+++ b/puppet/modules/socorro/files/etc_consul.d/config.json
@@ -1,0 +1,6 @@
+{
+    "server": true,
+    "data_dir": "/var/lib/consul",
+    "log_level": "INFO",
+    "ui_dir": "/usr/share/consul"
+}

--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -23,6 +23,7 @@ class socorro {
   package {
     [
       'epel-release',
+      'git',
       'yum-plugin-fastestmirror'
     ]:
     ensure  => latest,

--- a/puppet/modules/socorro/manifests/packer/base.pp
+++ b/puppet/modules/socorro/manifests/packer/base.pp
@@ -1,0 +1,109 @@
+# Set up basic Socorro requirements.
+class socorro::packer::base {
+
+  include socorro
+
+  service {
+    'httpd':
+      ensure  => stopped,
+      enable  => false,
+      require => Package['httpd'];
+
+    'postgresql-9.3':
+      ensure  => stopped,
+      enable  => false,
+      require => [
+        Package['postgresql93-server'],
+        File['pg_hba.conf'],
+      ];
+
+    'elasticsearch':
+      ensure  => stopped,
+      enable  => false,
+      require => Package['elasticsearch'];
+
+    'rabbitmq-server':
+      ensure  => stopped,
+      enable  => false,
+      require => Package['rabbitmq-server'];
+  }
+
+  yumrepo {
+    'elasticsearch':
+      baseurl => 'http://packages.elasticsearch.org/elasticsearch/1.4/centos',
+      gpgkey  => 'https://packages.elasticsearch.org/GPG-KEY-elasticsearch';
+    'PGDG':
+      baseurl => 'http://yum.postgresql.org/9.3/redhat/rhel-$releasever-$basearch',
+      gpgkey  => 'http://yum.postgresql.org/RPM-GPG-KEY-PGDG';
+  }
+
+  Yumrepo['elasticsearch', 'PGDG'] {
+    enabled  => 1,
+    gpgcheck => 1
+  }
+
+  package {
+    [
+      'httpd',
+      'java-1.7.0-openjdk',
+      'mod_wsgi',
+      'rabbitmq-server',
+      'supervisor',
+      'unzip'
+    ]:
+    ensure  => latest,
+    require => Package['epel-release', 'yum-plugin-fastestmirror']
+  }
+
+  package {
+    [
+      'postgresql93-contrib',
+      'postgresql93-devel',
+      'postgresql93-plperl',
+      'postgresql93-server'
+    ]:
+    ensure  => latest,
+    require => [
+      Yumrepo['PGDG'],
+      Package['ca-certificates']
+    ]
+  }
+
+  package {
+    'elasticsearch':
+      ensure  => latest,
+      require => [
+        Yumrepo['elasticsearch'],
+        Package['java-1.7.0-openjdk']
+      ]
+  }
+
+  file {
+    '/etc/socorro':
+      ensure => directory;
+
+    'pg_hba.conf':
+      ensure  => file,
+      path    => '/var/lib/pgsql/9.3/data/pg_hba.conf',
+      source  => 'puppet:///modules/socorro/var_lib_pgsql_9.3_data/pg_hba.conf',
+      owner   => 'postgres',
+      group   => 'postgres',
+      require => Package['postgresql93-server'],
+      notify  => Service['postgresql-9.3'];
+
+    'pgsql.sh':
+      ensure => file,
+      path   => '/etc/profile.d/pgsql.sh',
+      source => 'puppet:///modules/socorro/etc_profile.d/pgsql.sh',
+      owner  => 'root';
+
+    'elasticsearch.yml':
+      ensure  => file,
+      path    => '/etc/elasticsearch/elasticsearch.yml',
+      source  => 'puppet:///modules/socorro/etc_elasticsearch/elasticsearch.yml',
+      owner   => 'root',
+      require => Package['elasticsearch'],
+      notify  => Service['elasticsearch'];
+  }
+
+}

--- a/puppet/modules/socorro/manifests/packer/buildbox.pp
+++ b/puppet/modules/socorro/manifests/packer/buildbox.pp
@@ -1,0 +1,61 @@
+# Box used for building Socorro components.
+class socorro::packer::buildbox {
+
+  # Don't forget to include the common components!
+  include socorro
+
+  package {
+    [
+      'createrepo',
+      'gcc-c++',
+      'java-1.7.0-openjdk',
+      'java-1.7.0-openjdk-devel',
+      'libcurl-devel',
+      'libxml2-devel',
+      'libxslt-devel',
+      'make',
+      'mock',
+      'openldap-devel',
+      'python-devel',
+      'python-pip',
+      'rpm-build',
+      'rpm-sign',
+      'rpmdevtools',
+      'rsync',
+      'ruby-devel',
+      'subversion',
+      'time',
+      'unzip',
+      'vim'
+    ]:
+    ensure  => latest,
+    require => Package['epel-release']
+  }
+
+  # RHEL-alike and pip provider relationship status: It's Complicated
+  # Workaround is to have a symlink called "pip-python" because reasons.
+  # https://github.com/evenup/evenup-curator/issues/24 for example.
+  file {
+    '/usr/bin/pip-python':
+      ensure  => link,
+      target  => '/usr/bin/pip',
+      require => Package['python-pip']
+  }
+
+  package {
+    'awscli':
+      ensure   => latest,
+      provider => 'pip',
+      require  => File['/usr/bin/pip-python']
+  }
+
+  file {
+    '/etc/profile.d/rpmbuild.sh':
+      ensure => file,
+      source => 'puppet:///modules/socorro/etc_profile.d/rpmbuild.sh',
+      owner  => 'root',
+      group  => 'root'
+  }
+
+
+}

--- a/puppet/modules/socorro/manifests/role/consul.pp
+++ b/puppet/modules/socorro/manifests/role/consul.pp
@@ -1,0 +1,25 @@
+# Set up a consul node.
+class socorro::role::consul {
+
+  service {
+    'consul':
+      ensure  => running,
+      enable  => true,
+      require => File['/etc/consul.d/config.json']
+  }
+
+  package {
+    'consul':
+      ensure => latest
+  }
+
+  file {
+    '/etc/consul.d/config.json':
+      ensure  => file,
+      source  => 'puppet:///modules/socorro/etc_consul.d/config.json',
+      owner   => 'root',
+      group   => 'consul',
+      require => Package['consul']
+  }
+
+}

--- a/puppet/modules/socorro/manifests/role/symbolapi.pp
+++ b/puppet/modules/socorro/manifests/role/symbolapi.pp
@@ -1,0 +1,16 @@
+# Set up a symbolapi node.
+class socorro::role::symbolapi {
+
+  service {
+    'mozilla-snappy':
+      ensure  => running,
+      enable  => true,
+      require => Package['mozilla-snappy']
+  }
+
+  package {
+    'mozilla-snappy':
+      ensure=> latest
+  }
+
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -104,7 +104,7 @@ resource "aws_elb" "elb_for_symbolapi" {
 
 resource "aws_launch_configuration" "lc_for_symbolapi_asg" {
     name = "${var.environment}__lc_for_symbolapi_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.infra_repo} symbolapi"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} symbolapi"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "c4.xlarge"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
@@ -118,7 +118,7 @@ resource "aws_launch_configuration" "lc_for_symbolapi_asg" {
 
 resource "aws_launch_configuration" "lc_for_consul_asg" {
     name = "${var.environment}__lc_for_consul_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.infra_repo} consul"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} consul"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,39 @@ provider "aws" {
     secret_key = "${var.secret_key}"
 }
 
+# Once you're in, you're in.
+resource "aws_security_group" "private_to_private__any" {
+    name = "${var.environment}__private_to_private__any"
+    description = "Allow all private traffic."
+    ingress {
+        from_port = 0
+        to_port = 65535
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+            ]
+        }
+    ingress {
+        from_port = 0
+        to_port = 65535
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+            ]
+        }
+    ingress {
+        from_port = "-1"
+        to_port = "-1"
+        protocol = "icmp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+            ]
+        }
+    tags {
+        Environment = "${var.environment}"
+    }
+}
+
 resource "aws_security_group" "internet_to_any__ssh" {
     name = "${var.environment}__internet_to_any__ssh"
     description = "Allow (alt) SSH to any given node."
@@ -71,14 +104,27 @@ resource "aws_elb" "elb_for_symbolapi" {
 
 resource "aws_launch_configuration" "lc_for_symbolapi_asg" {
     name = "${var.environment}__lc_for_symbolapi_asg"
-    user_data = "${file(\"symbolapi_cloud-init.sh\")}"
+    user_data = "${file(\"socorro_role.sh\")} ${var.infra_repo} symbolapi"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "c4.xlarge"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     security_groups = [
         "${aws_security_group.internet_to_elb__http.name}",
         "${aws_security_group.elb_to_symbolapi__http.name}",
-        "${aws_security_group.internet_to_any__ssh.name}"
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+}
+
+resource "aws_launch_configuration" "lc_for_consul_asg" {
+    name = "${var.environment}__lc_for_consul_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.infra_repo} consul"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    security_groups = [
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
     ]
 }
 
@@ -98,4 +144,20 @@ resource "aws_autoscaling_group" "asg_for_symbolapi" {
     load_balancers = [
         "${var.environment}--elb-for-symbolapi"
     ]
+}
+
+resource "aws_autoscaling_group" "asg_for_consul" {
+    name = "${var.environment}__asg_for_consul"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    depends_on = [
+        "aws_launch_configuration.lc_for_consul_asg"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc_for_consul_asg.id}"
+    max_size = 5
+    min_size = 3
+    desired_capacity = 3
+    health_check_type = "EC2"
 }

--- a/terraform/socorro_role.sh
+++ b/terraform/socorro_role.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+DIR="/tmp/${RANDOM}-${RANDOM}"
+
+function socorro_role {
+    git clone $1 $DIR
+    /usr/bin/env FACTER_socorro_role=$2 \
+        puppet apply \
+        --modulepath=${DIR}/puppet/modules \
+        ${DIR}/puppet/manifests/default.pp
+}
+
+# Required variables will be inserted by Terraform.
+socorro_role \

--- a/terraform/socorro_role.sh
+++ b/terraform/socorro_role.sh
@@ -3,11 +3,17 @@
 DIR="/tmp/${RANDOM}-${RANDOM}"
 
 function socorro_role {
-    git clone $1 $DIR
+    mkdir $DIR
+    pushd $DIR
+    curl -O $1
+    # Yoink the filename from the end of the URL
+    ARCHIVE=`echo $1|awk -F'/' '{print $NF}'`
+    tar -xvzf $ARCHIVE
     /usr/bin/env FACTER_socorro_role=$2 \
         puppet apply \
         --modulepath=${DIR}/puppet/modules \
         ${DIR}/puppet/manifests/default.pp
+    popd
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/symbolapi_cloud-init.sh
+++ b/terraform/symbolapi_cloud-init.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-yum install -y mozilla-snappy
-systemctl start mozilla-snappy

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,6 +22,6 @@ variable "base_ami" {
 variable "alt_ssh_port" {
     default = 22123
 }
-variable "del_on_term" {
-    default = "false"
+variable "infra_repo" {
+    default = "https://github.com/mozilla/socorro-infra.git"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,6 +22,6 @@ variable "base_ami" {
 variable "alt_ssh_port" {
     default = 22123
 }
-variable "infra_repo" {
-    default = "https://github.com/mozilla/socorro-infra.git"
+variable "puppet_archive" {
+    default = "https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.packages-public/prov_cache/socorro-infra__puppet.tar.gz"
 }


### PR DESCRIPTION
### Details

This is a reasonably large set of diffs, so let's walk through the important bits. :dancers:

**`puppet/manifests/default.pp`**
* Previously this was only used during the Packer phase; I've added another block for the "role" phase (ASG provisioning).

**`puppet/modules/socorro/manifests/init.pp`**
* Previously, Git was only used by the Buildbox; however, it is now used to pull down the latest master of `socorro-infra`, so that the role can be provisioned.

**`puppet/modules/socorro/manifests/packer/*.pp`**
* With the exception of `Package['git']` these haven't changed - they've just been moved.

**`puppet/modules/socorro/manifests/role/consul.pp`**
* This sets up the [Consul](https://consul.io/) nodes with a minimum viable configuration.
* The service starts but will not form a cluster - there is a manual bootstrap that has to be performed. It's not so bad.

**`puppet/modules/socorro/manifests/role/symbolapi.pp`**
* This replaces `symbolapi_cloud-init.sh` (yay).

**`terraform/main.tf`**
* I've re-added the `private_to_private__any` rule. Consul uses five different ports and both TCP and UDP, so, this was easier. We can (and should) review our internal ACLs as a future optimisation.
* Line `107` (and similar on `121`) has this little gem of a hack:

    ```ini
    user_data = "${file(\"socorro_role.sh\")} ${var.infra_repo} symbolapi"
    ```
    This causes `socorro_role.sh` to be imported into `user-data` as expected, but then *concatenates* `${var.infra_repo} symbolapi` to the end of that script. Keep this in mind when we examine the script itself.
* It would appear that the default health check for ASG resources is `ELB`; I therefore had to explicitly set `health_check_type = "EC2"` in the `asg_for_consul` resource since it doesn't use an ELB.  We'll have to keep this in mind because it's easy to miss.

**`terraform/socorro_role.sh`**
* The `socorro_role` function is meant to clone `socorro-infra` and then apply the appropriate role - but where is it getting `$1` and `$2` from?  The function call on the final line contains a slash such that further input is expected - the "missing" next line is supplied by Terraform in the `user_data` definition.
* I can't tell whether this is super clever, super dirty, or both. :stuck_out_tongue_closed_eyes: 

**`terraform/variables.tf`**
* The actual location of the infra repo can be over-written in case one wanted to try out a different repo (for dev purposes, for example).

### Known bug!

The previous base AMI does *not* have `git` installed, which means that the provisioning step will currently fail. Solution:
* Merge this branch.
* Roll a new AMI from this branch.
* Update `variables.tf` with the new ID.
* Prepare PR and merge.

### Future improvements

* Add "environmental awareness" to `puppet/modules/socorro/manifests/init.pp`: have this download a *tagged release* of `socorro-infra` if we're Prod and pull master if we're stage.

### r?

@rhelmer :two_hearts: