### PR TITLE
fix bug 1118297 - terraform config for Socorro

### DIFF
--- a/puppet/modules/socorro/manifests/role/admin.pp
+++ b/puppet/modules/socorro/manifests/role/admin.pp
@@ -1,0 +1,9 @@
+# Set up a admin node.
+class socorro::role::admin {
+
+  package {
+    'socorro':
+      ensure=> latest
+  }
+
+}

--- a/puppet/modules/socorro/manifests/role/collector.pp
+++ b/puppet/modules/socorro/manifests/role/collector.pp
@@ -1,0 +1,21 @@
+# Set up a collector node.
+class socorro::role::collector {
+
+  service {
+    'httpd':
+      ensure  => running,
+      enable  => true,
+      require => Package['httpd'];
+
+    'socorro-collector':
+      ensure  => running,
+      enable  => true,
+      require => Package['socorro'];
+  }
+
+  package {
+    'socorro':
+      ensure=> latest
+  }
+
+}

--- a/puppet/modules/socorro/manifests/role/elasticsearch.pp
+++ b/puppet/modules/socorro/manifests/role/elasticsearch.pp
@@ -1,0 +1,19 @@
+# Set up an elasticsearch node.
+class socorro::role::elasticsearch {
+
+  service {
+    'elasticsearch':
+      ensure  => running,
+      enable  => true,
+      require => Package['socorro']
+  }
+
+  package {
+    'elasticsearch':
+      ensure=> latest;
+
+    'socorro':
+      ensure=> latest;
+  }
+
+}

--- a/puppet/modules/socorro/manifests/role/middleware.pp
+++ b/puppet/modules/socorro/manifests/role/middleware.pp
@@ -1,0 +1,21 @@
+# Set up a middleware node.
+class socorro::role::middleware {
+
+  service {
+    'httpd':
+      ensure  => running,
+      enable  => true,
+      require => Package['httpd'];
+
+    'socorro-middleware':
+      ensure  => running,
+      enable  => true,
+      require => Package['socorro'];
+  }
+
+  package {
+    'socorro':
+      ensure=> latest
+  }
+
+}

--- a/puppet/modules/socorro/manifests/role/postgres.pp
+++ b/puppet/modules/socorro/manifests/role/postgres.pp
@@ -1,0 +1,19 @@
+# Set up a postgrs node.
+class socorro::role::postgres {
+
+  service {
+    'postgresql93-server':
+      ensure  => running,
+      enable  => true,
+      require => Package['socorro']
+  }
+
+  package {
+    'postgresql93-server':
+      ensure=> latest;
+
+    'socorro':
+      ensure=> latest;
+  }
+
+}

--- a/puppet/modules/socorro/manifests/role/processor.pp
+++ b/puppet/modules/socorro/manifests/role/processor.pp
@@ -1,0 +1,16 @@
+# Set up a processor node.
+class socorro::role::processor {
+
+  service {
+    'socorro-processor':
+      ensure  => running,
+      enable  => true,
+      require => Package['socorro']
+  }
+
+  package {
+    'socorro':
+      ensure=> latest
+  }
+
+}

--- a/puppet/modules/socorro/manifests/role/rabbitmq.pp
+++ b/puppet/modules/socorro/manifests/role/rabbitmq.pp
@@ -1,0 +1,16 @@
+# Set up a rabbitmq node.
+class socorro::role::rabbitmq {
+
+  service {
+    'rabbitmq-server':
+      ensure  => running,
+      enable  => true,
+      require => Package['socorro']
+  }
+
+  package {
+    'rabbitmq-server':
+      ensure=> latest
+  }
+
+}

--- a/puppet/modules/socorro/manifests/role/webapp.pp
+++ b/puppet/modules/socorro/manifests/role/webapp.pp
@@ -1,0 +1,21 @@
+# Set up a webapp node.
+class socorro::role::webapp {
+
+  service {
+    'httpd':
+      ensure  => running,
+      enable  => true,
+      require => Package['httpd'];
+
+    'socorro-webapp':
+      ensure  => running,
+      enable  => true,
+      require => Package['socorro'];
+  }
+
+  package {
+    'socorro':
+      ensure=> latest
+  }
+
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -69,6 +69,7 @@ resource "aws_security_group" "internet_to_elb__http" {
     }
 }
 
+# symbolapi
 resource "aws_security_group" "elb_to_symbolapi__http" {
     name = "${var.environment}__elb_to_symbolapi__http"
     description = "Allow HTTP(S) from ELBs to symbolapi."
@@ -116,18 +117,6 @@ resource "aws_launch_configuration" "lc_for_symbolapi_asg" {
     ]
 }
 
-resource "aws_launch_configuration" "lc_for_consul_asg" {
-    name = "${var.environment}__lc_for_consul_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} consul"
-    image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "t2.micro"
-    key_name = "${lookup(var.ssh_key_name, var.region)}"
-    security_groups = [
-        "${aws_security_group.internet_to_any__ssh.name}",
-        "${aws_security_group.private_to_private__any.name}"
-    ]
-}
-
 resource "aws_autoscaling_group" "asg_for_symbolapi" {
     name = "${var.environment}__asg_for_symbolapi"
     availability_zones = [
@@ -146,6 +135,18 @@ resource "aws_autoscaling_group" "asg_for_symbolapi" {
     ]
 }
 
+resource "aws_launch_configuration" "lc_for_consul_asg" {
+    name = "${var.environment}__lc_for_consul_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} consul"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    security_groups = [
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+}
+
 resource "aws_autoscaling_group" "asg_for_consul" {
     name = "${var.environment}__asg_for_consul"
     availability_zones = [
@@ -160,4 +161,382 @@ resource "aws_autoscaling_group" "asg_for_consul" {
     min_size = 3
     desired_capacity = 3
     health_check_type = "EC2"
+}
+
+# collectors (crash-reports)
+resource "aws_security_group" "elb_to_collectors__http" {
+    name = "${var.environment}__elb_to_collectors__http"
+    description = "Allow HTTP(S) from ELBs to collectors."
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        security_groups = [
+            "${aws_security_group.internet_to_elb__http.id}"
+        ]
+    }
+    tags {
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_elb" "elb_for_collectors" {
+    name = "${var.environment}--elb-for-collectors"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    listener {
+        instance_port = 80
+        instance_protocol = "http"
+        lb_port = 80
+        lb_protocol = "http"
+    }
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.id}"
+    ]
+}
+
+resource "aws_launch_configuration" "lc_for_collectors_asg" {
+    name = "${var.environment}__lc_for_collectors_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} collectors"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.name}",
+        "${aws_security_group.elb_to_collectors__http.name}",
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+}
+
+resource "aws_autoscaling_group" "asg_for_collectors" {
+    name = "${var.environment}__asg_for_collectors"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    depends_on = [
+        "aws_launch_configuration.lc_for_collectors_asg"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc_for_collectors_asg.id}"
+    max_size = 1
+    min_size = 1
+    desired_capacity = 1
+    load_balancers = [
+        "${var.environment}--elb-for-collectors"
+    ]
+}
+
+# webapp (crash-stats)
+resource "aws_security_group" "elb_to_webapp__http" {
+    name = "${var.environment}__elb_to_webapp__http"
+    description = "Allow HTTP(S) from ELBs to webapp."
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        security_groups = [
+            "${aws_security_group.internet_to_elb__http.id}"
+        ]
+    }
+    tags {
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_elb" "elb_for_webapp" {
+    name = "${var.environment}--elb-for-webapp"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    listener {
+        instance_port = 80
+        instance_protocol = "http"
+        lb_port = 80
+        lb_protocol = "http"
+    }
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.id}"
+    ]
+}
+
+resource "aws_launch_configuration" "lc_for_webapp_asg" {
+    name = "${var.environment}__lc_for_webapp_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} webapp"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.name}",
+        "${aws_security_group.elb_to_webapp__http.name}",
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+}
+
+resource "aws_autoscaling_group" "asg_for_webapp" {
+    name = "${var.environment}__asg_for_webapp"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    depends_on = [
+        "aws_launch_configuration.lc_for_webapp_asg"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc_for_webapp_asg.id}"
+    max_size = 1
+    min_size = 1
+    desired_capacity = 1
+    load_balancers = [
+        "${var.environment}--elb-for-webapp"
+    ]
+}
+
+# middleware
+resource "aws_security_group" "elb_to_middleware__http" {
+    name = "${var.environment}__elb_to_middleware__http"
+    description = "Allow HTTP(S) from ELBs to middleware."
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        security_groups = [
+            "${aws_security_group.internet_to_elb__http.id}"
+        ]
+    }
+    tags {
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_elb" "elb_for_middleware" {
+    name = "${var.environment}--elb-for-middleware"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    listener {
+        instance_port = 80
+        instance_protocol = "http"
+        lb_port = 80
+        lb_protocol = "http"
+    }
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.id}"
+    ]
+}
+
+resource "aws_launch_configuration" "lc_for_middleware_asg" {
+    name = "${var.environment}__lc_for_middleware_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} middleware"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.name}",
+        "${aws_security_group.elb_to_middleware__http.name}",
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+}
+
+resource "aws_autoscaling_group" "asg_for_middleware" {
+    name = "${var.environment}__asg_for_middleware"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    depends_on = [
+        "aws_launch_configuration.lc_for_middleware_asg"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc_for_middleware_asg.id}"
+    max_size = 1
+    min_size = 1
+    desired_capacity = 1
+    load_balancers = [
+        "${var.environment}--elb-for-middleware"
+    ]
+}
+
+# processors
+resource "aws_launch_configuration" "lc_for_processors_asg" {
+    name = "${var.environment}__lc_for_processors_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} processors"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.name}",
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+}
+
+resource "aws_autoscaling_group" "asg_for_processors" {
+    name = "${var.environment}__asg_for_processors"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    depends_on = [
+        "aws_launch_configuration.lc_for_processors_asg"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc_for_processors_asg.id}"
+    max_size = 1
+    min_size = 1
+    desired_capacity = 1
+}
+
+# admin (crontabber)
+resource "aws_launch_configuration" "lc_for_admin_asg" {
+    name = "${var.environment}__lc_for_admin_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} admin"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.name}",
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+}
+
+resource "aws_autoscaling_group" "asg_for_admin" {
+    name = "${var.environment}__asg_for_admin"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    depends_on = [
+        "aws_launch_configuration.lc_for_admin_asg"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc_for_admin_asg.id}"
+    max_size = 1
+    min_size = 1
+    desired_capacity = 1
+}
+
+# RabbitMQ
+resource "aws_security_group" "elb_to_rabbitmq__http" {
+    name = "${var.environment}__elb_to_rabbitmq__http"
+    description = "Allow HTTP(S) from ELBs to rabbitmq."
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        security_groups = [
+            "${aws_security_group.internet_to_elb__http.id}"
+        ]
+    }
+    tags {
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_elb" "elb_for_rabbitmq" {
+    name = "${var.environment}--elb-for-rabbitmq"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    listener {
+        instance_port = 80
+        instance_protocol = "http"
+        lb_port = 80
+        lb_protocol = "http"
+    }
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.id}"
+    ]
+}
+
+resource "aws_launch_configuration" "lc_for_rabbitmq_asg" {
+    name = "${var.environment}__lc_for_rabbitmq_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} rabbitmq"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    security_groups = [
+        "${aws_security_group.internet_to_elb__http.name}",
+        "${aws_security_group.elb_to_rabbitmq__http.name}",
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+}
+
+resource "aws_autoscaling_group" "asg_for_rabbitmq" {
+    name = "${var.environment}__asg_for_rabbitmq"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b"
+    ]
+    depends_on = [
+        "aws_launch_configuration.lc_for_rabbitmq_asg"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc_for_rabbitmq_asg.id}"
+    max_size = 1
+    min_size = 1
+    desired_capacity = 1
+    load_balancers = [
+        "${var.environment}--elb-for-rabbitmq"
+    ]
+}
+
+
+# PostgreSQL
+resource "aws_instance" "postgres" {
+    ami = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    count = 1
+    security_groups = [
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+    block_device {
+        device_name = "/dev/sda1"
+        delete_on_termination = "${var.del_on_term}"
+    }
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} postgres"
+    tags {
+        Name = "${var.environment}__postgres_${count.index}"
+        Environment = "${var.environment}"
+    }
+}
+
+# Elastic Search
+resource "aws_instance" "elasticsearch" {
+    ami = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    count = 1
+    security_groups = [
+        "${aws_security_group.internet_to_any__ssh.name}",
+        "${aws_security_group.private_to_private__any.name}"
+    ]
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} elasticsearch"
+    tags {
+        Name = "${var.environment}__elasticsearch_${count.index}"
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_elb" "elb_for_elasticsearch" {
+    name = "${var.environment}--elb-for-elasticsearch"
+    availability_zones = [
+        "${aws_instance.elasticsearch.*.availability_zone}"
+    ]
+    listener {
+        instance_port = 9200
+        instance_protocol = "http"
+        lb_port = 9200
+        lb_protocol = "http"
+    }
+    # Sit in front of the elasticsearch.
+    instances = [
+        "${aws_instance.elasticsearch.*.id}"
+    ]
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,12 @@
 output "public_addr__symbolapi__http" {
     value = "${aws_elb.elb_for_symbolapi.dns_name}"
 }
+output "public_addr__collectors__http" {
+    value = "${aws_elb.elb_for_collectors.dns_name}"
+}
+output "public_addr__webapp__http" {
+    value = "${aws_elb.elb_for_webapp.dns_name}"
+}
+output "public_addr__middleware__http" {
+    value = "${aws_elb.elb_for_middleware.dns_name}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,3 +25,7 @@ variable "alt_ssh_port" {
 variable "puppet_archive" {
     default = "https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.packages-public/prov_cache/socorro-infra__puppet.tar.gz"
 }
+# NOTE - this deletes EBS devices, only change it for testing purposes!
+variable "del_on_term" {
+    default = "false"
+}


### PR DESCRIPTION
As we discussed, ```main.tf``` is getting ungainly with so many resources, so we're probably going to want to split this up (multiple ```.tf``` files and/or use terraform modules for some of the common pattern here, like the ELB+ASG+LC combo we do for almost everything), but I think this is a good enough start.

The rule of thumb I have used here is that plain instances are only used if the instances aren't ephemeral, so ES (which uses instance storage) and PG (which uses EBS), these two are sensitive to data loss (it'll take quite a while to recover.) Therefore these two services need to be monitored and recovered manually, every other service should be able to auto-recover.

Besides testing this more, I'd like to figure out why I get ```Error retrieving AutoScaling groups: Throttling: Rate exceeded``` when I ```terraform destroy``` before we merge this - presumably terraform (v0.3.7) is querying the AWS API too quickly during ```destroy```.