### PR TITLE
add requirement for fpm & update base ID

### DIFF
--- a/puppet/modules/socorro/manifests/packer/buildbox.pp
+++ b/puppet/modules/socorro/manifests/packer/buildbox.pp
@@ -61,7 +61,8 @@ class socorro::packer::buildbox {
   package {
     'fpm':
       ensure   => latest,
-      provider => 'gem'
+      provider => 'gem',
+      require  => Package['ruby-devel']
   }
 
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,7 +16,7 @@ variable "ssh_key_name" {
 }
 variable "base_ami" {
     default = {
-        us-west-2 = "ami-7b64474b"
+        us-west-2 = "ami-95a885a5"
     }
 }
 variable "alt_ssh_port" {


### PR DESCRIPTION
FPM requires `ruby-devel` - didn't catch it the first time because idempotence is a cruel joke.

Also updated the Base AMI ID (re: PR #29)

@rhelmer `r?`