### PR TITLE
add golang and mercurial to build deadci

### DIFF
--- a/puppet/modules/socorro/manifests/packer/buildbox.pp
+++ b/puppet/modules/socorro/manifests/packer/buildbox.pp
@@ -8,6 +8,7 @@ class socorro::packer::buildbox {
     [
       'createrepo',
       'gcc-c++',
+      'golang',
       'java-1.7.0-openjdk-devel',
       'libcurl-devel',
       'libxml2-devel',
@@ -15,6 +16,7 @@ class socorro::packer::buildbox {
       'nodejs-less',
       'make',
       'mock',
+      'mercurial',
       'openldap-devel',
       'python-devel',
       'python-pip',


### PR DESCRIPTION
Necessary in order to build DeadCI from source (which we have to do until such a time as my [PR](https://github.com/phayes/deadci/pull/2) is accepted).

@rhelmer `r?`