### PR TITLE
bug 1146537; adjust cfg dir (upstream), split consul client & server

### DIFF
--- a/puppet/modules/socorro/files/etc_consul.d/config.json
+++ b/puppet/modules/socorro/files/etc_consul.d/config.json
@@ -1,7 +1,0 @@
-{
-    "server": true,
-    "bootstrap_expect": 3,
-    "data_dir": "/var/lib/consul",
-    "log_level": "INFO",
-    "ui_dir": "/usr/share/consul"
-}

--- a/puppet/modules/socorro/files/etc_consul/common.json
+++ b/puppet/modules/socorro/files/etc_consul/common.json
@@ -1,0 +1,4 @@
+{
+    "data_dir": "/var/lib/consul",
+    "log_level": "INFO",
+}

--- a/puppet/modules/socorro/files/etc_consul/server.json
+++ b/puppet/modules/socorro/files/etc_consul/server.json
@@ -1,0 +1,4 @@
+{
+    "server": true,
+    "bootstrap_expect": 3
+}

--- a/puppet/modules/socorro/files/etc_consul/ui.json
+++ b/puppet/modules/socorro/files/etc_consul/ui.json
@@ -1,0 +1,3 @@
+{
+    "ui_dir": "/usr/share/consul"
+}

--- a/puppet/modules/socorro/files/etc_sysconfig/consul
+++ b/puppet/modules/socorro/files/etc_sysconfig/consul
@@ -1,0 +1,1 @@
+CMD_OPTS="agent -config-dir=/etc/consul"

--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -2,6 +2,14 @@
 class socorro {
 
   service {
+    'consul':
+      ensure  => running,
+      enabled => true,
+      require => File[
+        '/etc/consul/common.json',
+        '/etc/sysconfig/consul'
+      ];
+
     'sshd':
       ensure  => running,
       enable  => true,
@@ -32,6 +40,8 @@ class socorro {
 
   package {
     [
+      'consul',
+      'envconsul',
       'hiera-consul',
       'hiera-s3'
     ]:
@@ -45,7 +55,6 @@ class socorro {
 
   file {
     'selinux_config':
-      ensure => file,
       path   => '/etc/selinux/config',
       source => 'puppet:///modules/socorro/etc_selinux/config',
       owner  => 'root',
@@ -53,12 +62,27 @@ class socorro {
       mode   => '0644';
 
     'sshd_config':
-      ensure => file,
       path   => '/etc/ssh/sshd_config',
       source => 'puppet:///modules/socorro/etc_ssh/sshd_config',
       owner  => 'root',
       group  => 'root',
       mode   => '0644'
+  }
+
+  file {
+    '/etc/consul/common.json':
+      source  => 'puppet:///modules/socorro/etc_consul/common.json',
+      owner   => 'root',
+      group   => 'consul',
+      mode    => '0640',
+      require => Package['consul'];
+
+    '/etc/sysconfig/consul':
+      source  => 'puppet:///modules/socorro/etc_sysconfig/consul',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      require => Package['consul']
   }
 
 }

--- a/puppet/modules/socorro/manifests/role/consul.pp
+++ b/puppet/modules/socorro/manifests/role/consul.pp
@@ -1,28 +1,37 @@
-# Set up a consul node.
+# Set up a Consul Server node.
 class socorro::role::consul {
 
   service {
     'consul':
-      ensure  => running,
-      enable  => true,
-      require => File['/etc/consul.d/config.json']
+      ensure    => running,
+      enable    => true,
+      subscribe => File[
+        '/etc/consul/config.json',
+        '/etc/consul/ui.json'
+      ]
   }
 
   package {
     [
       'bind-utils',
-      'consul'
+      'consul-ui'
     ]:
     ensure => latest
   }
 
   file {
-    '/etc/consul.d/config.json':
-      ensure  => file,
-      source  => 'puppet:///modules/socorro/etc_consul.d/config.json',
+    '/etc/consul/server.json':
+      source => 'puppet:///modules/socorro/etc_consul/server.json',
+      owner  => 'root',
+      group  => 'consul',
+      mode   => '0640';
+
+    '/etc/consul/ui.json':
+      source  => 'puppet:///modules/socorro/etc_consul/ui.json',
       owner   => 'root',
       group   => 'consul',
-      require => Package['consul']
+      mode    => '0640',
+      require => Package['consul-ui']
   }
 
 }


### PR DESCRIPTION
This splits out the configs for Consul clients and servers (previously we only dealt with servers) by putting the client portions in Base and the server portions (only) in the appropriate role.

As a side-effect, this also fixes [bug 1146537](https://bugzilla.mozilla.org/show_bug.cgi?id=1146537), which addresses a change in the config dir path.

This will require the Base and Buildbox AMIs to be rebuilt.

@rhelmer `r?`