### PR TITLE
fix bug 1146449; pass the secret bucket name to Hiera on provision

### DIFF
--- a/puppet/modules/socorro/files/etc_puppet/hiera.yaml
+++ b/puppet/modules/socorro/files/etc_puppet/hiera.yaml
@@ -1,0 +1,14 @@
+---
+:backends:
+    - consul
+    - S3
+
+:consul:
+    :host: 127.0.0.1
+    :port: 8500
+    :paths:
+        - /v1/kv/hiera
+
+:s3:
+    :bucket: '@@@SECRET_BUCKET@@@'
+    :prefix: 'hiera/'

--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -82,7 +82,15 @@ class socorro {
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
-      require => Package['consul']
+      require => Package['consul'];
+
+    # Puppet is already running when this lands, thus it is not available now.
+    # It is available on any subsequent run, such as during role provision.
+    '/etc/puppet/hiera.yaml':
+      source => 'puppet:///modules/socorro/etc_puppet/hiera.yaml',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644'
   }
 
 }

--- a/terraform/consul/main.tf
+++ b/terraform/consul/main.tf
@@ -80,7 +80,7 @@ resource "aws_security_group" "internet_to_consul__ssh" {
 
 resource "aws_launch_configuration" "lc_for_consul_asg" {
     name = "${var.environment}__lc_for_consul_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} consul"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} consul ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -105,7 +105,7 @@ resource "aws_elb" "elb_for_symbolapi" {
 
 resource "aws_launch_configuration" "lc_for_symbolapi_asg" {
     name = "${var.environment}__lc_for_symbolapi_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} symbolapi"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} symbolapi ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "c4.xlarge"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
@@ -171,7 +171,7 @@ resource "aws_elb" "elb_for_collectors" {
 
 resource "aws_launch_configuration" "lc_for_collectors_asg" {
     name = "${var.environment}__lc_for_collectors_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} collector"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} collector ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
@@ -237,7 +237,7 @@ resource "aws_elb" "elb_for_webapp" {
 
 resource "aws_launch_configuration" "lc_for_webapp_asg" {
     name = "${var.environment}__lc_for_webapp_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} webapp"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} webapp ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
@@ -303,7 +303,7 @@ resource "aws_elb" "elb_for_middleware" {
 
 resource "aws_launch_configuration" "lc_for_middleware_asg" {
     name = "${var.environment}__lc_for_middleware_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} middleware"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} middleware ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
@@ -336,7 +336,7 @@ resource "aws_autoscaling_group" "asg_for_middleware" {
 # processors
 resource "aws_launch_configuration" "lc_for_processors_asg" {
     name = "${var.environment}__lc_for_processors_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} processor"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} processor ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
@@ -365,7 +365,7 @@ resource "aws_autoscaling_group" "asg_for_processors" {
 # admin (crontabber)
 resource "aws_launch_configuration" "lc_for_admin_asg" {
     name = "${var.environment}__lc_for_admin_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} admin"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} admin ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
@@ -427,7 +427,7 @@ resource "aws_elb" "elb_for_rabbitmq" {
 
 resource "aws_launch_configuration" "lc_for_rabbitmq_asg" {
     name = "${var.environment}__lc_for_rabbitmq_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} rabbitmq"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} rabbitmq ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
@@ -472,7 +472,7 @@ resource "aws_instance" "postgres" {
         device_name = "/dev/sda1"
         delete_on_termination = "${var.del_on_term}"
     }
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} postgres"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} postgres ${var.secret_bucket}"
     tags {
         Name = "${var.environment}__postgres_${count.index}"
         Environment = "${var.environment}"
@@ -489,7 +489,7 @@ resource "aws_instance" "elasticsearch" {
         "${aws_security_group.internet_to_any__ssh.name}",
         "${aws_security_group.private_to_private__any.name}"
     ]
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} elasticsearch"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} elasticsearch ${var.secret_bucket}"
     tags {
         Name = "${var.environment}__elasticsearch_${count.index}"
         Environment = "${var.environment}"
@@ -549,7 +549,7 @@ resource "aws_elb" "elb_for_buildbox" {
 
 resource "aws_launch_configuration" "lc_for_buildbox_asg" {
     name = "${var.environment}__lc_for_buildbox_asg"
-    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} buildbox"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} buildbox ${var.secret_bucket}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"

--- a/terraform/socorro_role.sh
+++ b/terraform/socorro_role.sh
@@ -3,12 +3,19 @@
 DIR="/tmp/${RANDOM}-${RANDOM}"
 
 function socorro_role {
+    # Set up the working dir.
     mkdir $DIR
     pushd $DIR
+
+    # Provide the secret bucket name to Hiera (hiera-s3).
+    sed -i "s:@@@SECRET_BUCKET@@@:${3}:" /etc/puppet/hiera.yaml
+
+    # Acquire the Puppet archive.
     curl -O $1
     # Yoink the filename from the end of the URL
     ARCHIVE=`echo $1|awk -F'/' '{print $NF}'`
     tar -xvzf $ARCHIVE
+    # Provision the role.
     /usr/bin/env FACTER_socorro_role=$2 \
         puppet apply \
         --modulepath=${DIR}/puppet/modules \

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,6 +1,7 @@
 variable "environment" {}
 variable "access_key" {}
 variable "secret_key" {}
+variable "secret_bucket" {}
 variable "ssh_key_file" {
     default = {
         us-west-2 = "socorro__us-west-2.pem"


### PR DESCRIPTION
I am extending the pattern of passing arbitrary information (in this case, the secret bucket name) via `user_data`. This value is then picked up (positionally) by `socorro_role.sh` and applied to `hiera.yaml`, thus allowing us to configure `hiera-s3` without exposing the name of the secret bucket.  Once again, I'm not sure if this is clever or janky - possibly both - but it should work. :smiling_imp: 

This also touches on [bug 1146447](https://bugzilla.mozilla.org/show_bug.cgi?id=1146447).

@rhelmer `r?`