### PR TITLE
ipv4 only for Yum in AWS. also fix typo.

### DIFF
--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -1,10 +1,21 @@
 # Elements common to all Socorro boxes.
 class socorro {
 
+  # Yum will sometimes resolve and attempt to use IPv6 addresses. This is a
+  # problem in AWS and can cause random errors (fun!).
+  $yum_ipv4_exec = $::bios_version ? {
+    /.*amazon.*/ => '/usr/bin/echo "ip_resolve=4" >> /etc/yum.conf',
+    default      => '/usr/bin/true'
+  }
+  exec {
+    'yum_ipv4_check':
+      command => $yum_ipv4_exec
+  }
+
   service {
     'consul':
       ensure  => running,
-      enabled => true,
+      enable  => true,
       require => File[
         '/etc/consul/common.json',
         '/etc/sysconfig/consul'
@@ -18,7 +29,8 @@ class socorro {
 
   package {
     'ca-certificates':
-      ensure => latest
+      ensure  => latest,
+      require => Exec['yum_ipv4_check']
   }
 
   package {


### PR DESCRIPTION
Yum occasionally resolves and attempts to use IPv6 addresses, which is fine *unless* you're in an IPv4-only environment such as AWS, then it's a source of whackadoodle Yum errors.  This PR addresses that problem by adding `ip_resolve=4` to [yum.conf](http://man7.org/linux/man-pages/man5/yum.conf.5.html) if the `bios_version` fact has `amazon` in it.

I also fixed a typo in the Consul service resource (oops).

This will require the Base and Buildbox AMIs to be rebuilt (which I'm doing right now) and the Puppet provision archive to be updated (which I'll do once the Buildbox AMI has been rebuilt).

@rhelmer `r?`