### PR TITLE
bug 1148302 - run crashmover on collectors

### DIFF
--- a/puppet/modules/socorro/manifests/role/collector.pp
+++ b/puppet/modules/socorro/manifests/role/collector.pp
@@ -11,6 +11,11 @@ class socorro::role::collector {
       ensure  => running,
       enable  => true,
       require => Package['socorro'];
+
+    'socorro-crashmover':
+      ensure  => running,
+      enable  => true,
+      require => Package['socorro'];
   }
 
   package {


### PR DESCRIPTION
? @phrawzty - this only partially addresses bug 1148302, it's what the configs in ```socorro-config``` are expecting though (collection to disk, crashmover service to move those into S3+Rabbit)