### PR TITLE
bug 1152427 - use internal ELBs for ES+Rabbit, upgrade to tform 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ sudo: no
 language: python
 before_install:
   - gem install puppet puppet-lint
-  - pushd terraform; wget 'https://dl.bintray.com/mitchellh/terraform/terraform_0.3.7_linux_amd64.zip'; unzip -u terraform_0.3.7_linux_amd64.zip; popd
+  - pushd terraform; wget 'https://dl.bintray.com/mitchellh/terraform/terraform_0.4.0_linux_amd64.zip'; unzip -u terraform_0.4.0_linux_amd64.zip; popd
 
 install: false
 
 script:
   - puppet-lint --with-filename --no-80chars-check --no-autoloader_layout-check --fail-on-warnings puppet/
   - puppet parser validate `find puppet/ -name '*.pp'`
-  - pushd terraform; ./terraform plan -var="environment=blah" -var="secret_key=FAKE" -var="access_key=FAKE"; popd
-  - pushd terraform/consul; ../terraform plan -var="environment=blah" -var="secret_key=FAKE" -var="access_key=FAKE"; popd
+  - find ./terraform -type d -maxdepth 1 | while read role; do pushd $role; ../terraform plan -var="environment=FAKE" -var="secret_key=FAKE" -var="access_key=FAKE" -var="subnets=FAKE" -var="secret_bucket=FAKE"; popd; done

--- a/terraform/admin/main.tf
+++ b/terraform/admin/main.tf
@@ -4,22 +4,6 @@ provider "aws" {
     secret_key = "${var.secret_key}"
 }
 
-resource "aws_security_group" "private_to_admin__icmp" {
-    name = "${var.environment}__private_to_admin__icmp"
-    description = "Allow pings from within the VPC."
-    ingress {
-        from_port = "-1"
-        to_port = "-1"
-        protocol = "icmp"
-        cidr_blocks = [
-            "172.31.0.0/16"
-        ]
-    }
-    tags {
-        Environment = "${var.environment}"
-    }
-}
-
 resource "aws_security_group" "any_to_admin__ssh" {
     name = "${var.environment}__any_to_admin__ssh"
     description = "Allow (alt) SSH to the Admin node."
@@ -43,15 +27,16 @@ resource "aws_launch_configuration" "lc_for_admin_asg" {
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
-    security_groups = [
-        "${aws_security_group.any_to_admin__ssh.name}",
-        "${aws_security_group.private_to_admin__icmp.name}"
-    ]
     iam_instance_profile = "generic"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.any_to_admin__ssh.id}"
+    ]
 }
 
 resource "aws_autoscaling_group" "asg_for_admin" {
     name = "${var.environment}__asg_for_admin"
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
     availability_zones = [
         "${var.region}a",
         "${var.region}b",

--- a/terraform/consul/main.tf
+++ b/terraform/consul/main.tf
@@ -62,22 +62,6 @@ resource "aws_security_group" "private_to_consul__consul" {
     }
 }
 
-resource "aws_security_group" "private_to_consul__icmp" {
-    name = "${var.environment}__private_to_consul__icmp"
-    description = "Allow pings from within the VPC."
-    ingress {
-        from_port = "-1"
-        to_port = "-1"
-        protocol = "icmp"
-        cidr_blocks = [
-            "172.31.0.0/16"
-        ]
-    }
-    tags {
-        Environment = "${var.environment}"
-    }
-}
-
 resource "aws_security_group" "internet_to_consul__ssh" {
     name = "${var.environment}__internet_to_consul__ssh"
     description = "Allow (alt) SSH to any given node."
@@ -100,15 +84,17 @@ resource "aws_launch_configuration" "lc_for_consul_asg" {
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
-    security_groups = [
-        "${aws_security_group.private_to_consul__consul.name}",
-        "${aws_security_group.internet_to_consul__ssh.name}"
-    ]
     iam_instance_profile = "generic"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.internet_to_consul__ssh.id}",
+        "${aws_security_group.private_to_consul__consul.id}"
+    ]
 }
 
 resource "aws_autoscaling_group" "asg_for_consul" {
     name = "${var.environment}__asg_for_consul"
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
     availability_zones = [
         "${var.region}a",
         "${var.region}b",

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -25,22 +25,6 @@ resource "aws_security_group" "private_to_elasticsearch__elasticsearch" {
     }
 }
 
-resource "aws_security_group" "private_to_elasticsearch__icmp" {
-    name = "${var.environment}__private_to_elasticsearch__icmp"
-    description = "Allow pings from within the VPC."
-    ingress {
-        from_port = "-1"
-        to_port = "-1"
-        protocol = "icmp"
-        cidr_blocks = [
-            "172.31.0.0/16"
-        ]
-    }
-    tags {
-        Environment = "${var.environment}"
-    }
-}
-
 resource "aws_security_group" "any_to_elasticsearch__ssh" {
     name = "${var.environment}__any_to_elasticsearch__ssh"
     description = "Allow (alt) SSH to the Elasticsearch node."
@@ -59,11 +43,8 @@ resource "aws_security_group" "any_to_elasticsearch__ssh" {
 
 resource "aws_elb" "elb_for_elasticsearch" {
     name = "${var.environment}--elb-for-elasticsearch"
-    availability_zones = [
-        "${var.region}a",
-        "${var.region}b",
-        "${var.region}c"
-    ]
+    internal = true
+    subnets = ["${split(",", var.subnets)}"]
     listener {
         instance_port = 9200
         instance_protocol = "http"
@@ -81,12 +62,12 @@ resource "aws_launch_configuration" "lc_for_elasticsearch_asg" {
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
-    security_groups = [
-        "${aws_security_group.private_to_elasticsearch__elasticsearch.name}",
-        "${aws_security_group.any_to_elasticsearch__ssh.name}",
-        "${aws_security_group.private_to_elasticsearch__icmp.name}"
-    ]
     iam_instance_profile = "generic"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.private_to_elasticsearch__elasticsearch.id}",
+        "${aws_security_group.any_to_elasticsearch__ssh.id}"
+    ]
 }
 
 resource "aws_autoscaling_group" "asg_for_elasticsearch" {
@@ -96,6 +77,7 @@ resource "aws_autoscaling_group" "asg_for_elasticsearch" {
         "${var.region}b",
         "${var.region}c"
     ]
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
     depends_on = [
         "aws_launch_configuration.lc_for_elasticsearch_asg"
     ]

--- a/terraform/postgres/main.tf
+++ b/terraform/postgres/main.tf
@@ -20,22 +20,6 @@ resource "aws_security_group" "private_to_postgres__postgres" {
     }
 }
 
-resource "aws_security_group" "private_to_postgres__icmp" {
-    name = "${var.environment}__private_to_postgres__icmp"
-    description = "Allow pings from within the VPC."
-    ingress {
-        from_port = "-1"
-        to_port = "-1"
-        protocol = "icmp"
-        cidr_blocks = [
-            "172.31.0.0/16"
-        ]
-    }
-    tags {
-        Environment = "${var.environment}"
-    }
-}
-
 resource "aws_security_group" "any_to_postgres__ssh" {
     name = "${var.environment}__any_to_postgres__ssh"
     description = "Allow (alt) SSH to the Postgres node."
@@ -59,10 +43,9 @@ resource "aws_instance" "postgres" {
     count = 1
     security_groups = [
         "${aws_security_group.private_to_postgres__postgres.name}",
-        "${aws_security_group.any_to_postgres__ssh.name}",
-        "${aws_security_group.private_to_postgres__icmp.name}"
+        "${aws_security_group.any_to_postgres__ssh.name}"
     ]
-    block_device {
+    ebs_block_device {
         device_name = "/dev/sda1"
         delete_on_termination = "${var.del_on_term}"
     }

--- a/terraform/processor/main.tf
+++ b/terraform/processor/main.tf
@@ -4,22 +4,6 @@ provider "aws" {
     secret_key = "${var.secret_key}"
 }
 
-resource "aws_security_group" "private_to_processor__icmp" {
-    name = "${var.environment}__private_to_processor__icmp"
-    description = "Allow pings from within the VPC."
-    ingress {
-        from_port = "-1"
-        to_port = "-1"
-        protocol = "icmp"
-        cidr_blocks = [
-            "172.31.0.0/16"
-        ]
-    }
-    tags {
-        Environment = "${var.environment}"
-    }
-}
-
 resource "aws_security_group" "any_to_processor__ssh" {
     name = "${var.environment}__any_to_processor__ssh"
     description = "Allow (alt) SSH to the Processor node."
@@ -91,16 +75,17 @@ resource "aws_launch_configuration" "lc_for_processor_asg" {
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
-    security_groups = [
-        "${aws_security_group.elb_to_processor__http.name}",
-        "${aws_security_group.any_to_processor__ssh.name}",
-        "${aws_security_group.private_to_processor__icmp.name}"
-    ]
     iam_instance_profile = "generic"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.elb_to_processor__http.id}",
+        "${aws_security_group.any_to_processor__ssh.id}"
+    ]
 }
 
 resource "aws_autoscaling_group" "asg_for_processor" {
     name = "${var.environment}__asg_for_processor"
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
     availability_zones = [
         "${var.region}a",
         "${var.region}b",

--- a/terraform/symbolapi/main.tf
+++ b/terraform/symbolapi/main.tf
@@ -4,22 +4,6 @@ provider "aws" {
     secret_key = "${var.secret_key}"
 }
 
-resource "aws_security_group" "private_to_symbolapi__icmp" {
-    name = "${var.environment}__private_to_symbolapi__icmp"
-    description = "Allow pings from within the VPC."
-    ingress {
-        from_port = "-1"
-        to_port = "-1"
-        protocol = "icmp"
-        cidr_blocks = [
-            "172.31.0.0/16"
-        ]
-    }
-    tags {
-        Environment = "${var.environment}"
-    }
-}
-
 resource "aws_security_group" "any_to_symbolapi__ssh" {
     name = "${var.environment}__any_to_symbolapi__ssh"
     description = "Allow (alt) SSH to the SymbolAPI node."
@@ -92,16 +76,17 @@ resource "aws_launch_configuration" "lc_for_symbolapi_asg" {
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "c4.xlarge"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
-    security_groups = [
-        "${aws_security_group.elb_to_symbolapi__http.name}",
-        "${aws_security_group.any_to_symbolapi__ssh.name}",
-        "${aws_security_group.private_to_symbolapi__icmp.name}"
-    ]
     iam_instance_profile = "generic"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.elb_to_symbolapi__http.id}",
+        "${aws_security_group.any_to_symbolapi__ssh.id}"
+    ]
 }
 
 resource "aws_autoscaling_group" "asg_for_symbolapi" {
     name = "${var.environment}__asg_for_symbolapi"
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
     availability_zones = [
         "${var.region}a",
         "${var.region}b",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,6 +2,7 @@ variable "environment" {}
 variable "access_key" {}
 variable "secret_key" {}
 variable "secret_bucket" {}
+variable "subnets" {}
 variable "ssh_key_file" {
     default = {
         us-west-2 = "socorro__us-west-2.pem"

--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -4,22 +4,6 @@ provider "aws" {
     secret_key = "${var.secret_key}"
 }
 
-resource "aws_security_group" "private_to_webapp__icmp" {
-    name = "${var.environment}__private_to_webapp__icmp"
-    description = "Allow pings from within the VPC."
-    ingress {
-        from_port = "-1"
-        to_port = "-1"
-        protocol = "icmp"
-        cidr_blocks = [
-            "172.31.0.0/16"
-        ]
-    }
-    tags {
-        Environment = "${var.environment}"
-    }
-}
-
 resource "aws_security_group" "any_to_webapp__ssh" {
     name = "${var.environment}__any_to_webapp__ssh"
     description = "Allow (alt) SSH to the Webapp node."
@@ -92,16 +76,17 @@ resource "aws_launch_configuration" "lc_for_webapp_asg" {
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
-    security_groups = [
-        "${aws_security_group.elb_to_webapp__http.name}",
-        "${aws_security_group.any_to_webapp__ssh.name}",
-        "${aws_security_group.private_to_webapp__icmp.name}"
-    ]
     iam_instance_profile = "generic"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.elb_to_webapp__http.id}",
+        "${aws_security_group.any_to_webapp__ssh.id}"
+    ]
 }
 
 resource "aws_autoscaling_group" "asg_for_webapp" {
     name = "${var.environment}__asg_for_webapp"
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
     availability_zones = [
         "${var.region}a",
         "${var.region}b",


### PR DESCRIPTION
@phrawzty, I spent some time today getting our config working in Terraform 0.4 and learned an interesting thing - our account only supports VPC EC2 infra and not Classic. You can see this by going here:

https://console.aws.amazon.com/ec2/v2/home?region=us-west-2

Look at "Supported Platforms" on the right, and "Default VPC" below that. That's why we're getting a default VPC and subnets created for us, and our infra is going into them. As of Terraform 0.4 this means that we have to start specifying our subnet IDs to our AutoScaling Groups.

Thanks to @phinze for finding this - this looked like a different bug at first, and it took a while to figure out that's why we were still hitting the issue.

Incidentally, understanding this helped me to see how we can configure internal ELBs - I've tested at least ```Collector``` and ```Elasticsearch``` roles and they seem to work!

The only downside I can see so far is that nodes now are in the VPC with no public IP address, so we're going to need to figure out some way to SSH into the nodes (bastion host or VPN.)