### PR TITLE
fix bug 1155504 - add crash-analysis host

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -14,6 +14,7 @@ node default {
     'buildbox': { include socorro::role::buildbox }
     'symbolapi': { include socorro::role::symbolapi }
     'admin': { include socorro::role::admin }
+    'analysis': { include socorro::role::analysis }
     'collector': { include socorro::role::collector }
     'elasticsearch': { include socorro::role::elasticsearch }
     'postgres': { include socorro::role::postgres }

--- a/puppet/modules/socorro/manifests/role/analysis.pp
+++ b/puppet/modules/socorro/manifests/role/analysis.pp
@@ -1,0 +1,19 @@
+# Set up an analysis node.
+class socorro::role::analysis {
+
+  service {
+    'nginx':
+      ensure  => running,
+      enable  => true,
+      require => Package['nginx']
+  }
+
+  package {
+    'nginx':
+      ensure=> latest;
+
+    'php-cli':
+      ensure=> latest;
+  }
+
+}

--- a/terraform/analysis/main.tf
+++ b/terraform/analysis/main.tf
@@ -1,0 +1,131 @@
+provider "aws" {
+    region = "${var.region}"
+    access_key = "${var.access_key}"
+    secret_key = "${var.secret_key}"
+}
+
+resource "aws_security_group" "any_to_analysis__ssh" {
+    name = "${var.environment}__any_to_analysis__ssh"
+    description = "Allow (alt) SSH to the CrashAnalysis node."
+    ingress {
+        from_port = "${var.alt_ssh_port}"
+        to_port = "${var.alt_ssh_port}"
+        protocol = "tcp"
+        cidr_blocks = [
+            "0.0.0.0/0"
+        ]
+    }
+    tags {
+        Environment = "${var.environment}"
+        role = "crash-analysis"
+        project = "socorro"
+    }
+}
+
+resource "aws_security_group" "internet_to_analysis_elb__http" {
+    name = "${var.environment}__internet_to_analysis_elb__http"
+    description = "Allow incoming traffic from Internet to HTTP on ELBs."
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        cidr_blocks = [
+            "0.0.0.0/0"
+        ]
+    }
+    tags {
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_security_group" "internet_to_analysis_elb__https" {
+    name = "${var.environment}__internet_to_analysis_elb__https"
+    description = "Allow incoming traffic from Internet to HTTPS on ELBs."
+    ingress {
+        from_port = 443
+        to_port = 443
+        protocol = "tcp"
+        cidr_blocks = [
+            "0.0.0.0/0"
+        ]
+    }
+    tags {
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_security_group" "elb_to_analysis__http" {
+    name = "${var.environment}__elb_to_analysis__http"
+    description = "Allow HTTP from ELBs to analysis."
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        security_groups = [
+            "${aws_security_group.internet_to_analysis_elb__http.id}"
+        ]
+    }
+    tags {
+        Environment = "${var.environment}"
+    }
+}
+
+resource "aws_elb" "elb_for_analysis" {
+    name = "${var.environment}--elb-for-analysis"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b",
+        "${var.region}c"
+    ]
+    listener {
+        instance_port = 80
+        instance_protocol = "http"
+        lb_port = 80
+        lb_protocol = "http"
+    }
+    listener {
+        instance_port = 80
+        instance_protocol = "http"
+        lb_port = 443
+        lb_protocol = "https"
+        ssl_certificate_id = "${var.analysis_cert}"
+    }
+    security_groups = [
+        "${aws_security_group.internet_to_analysis_elb__https.id}",
+        "${aws_security_group.internet_to_analysis_elb__http.id}"
+    ]
+}
+
+resource "aws_launch_configuration" "lc_for_analysis_asg" {
+    name = "${var.environment}__lc_for_analysis_asg"
+    user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} analysis ${var.secret_bucket}"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "t2.micro"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    iam_instance_profile = "generic"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.elb_to_analysis__http.id}",
+        "${aws_security_group.any_to_analysis__ssh.id}"
+    ]
+}
+
+resource "aws_autoscaling_group" "asg_for_analysis" {
+    name = "${var.environment}__asg_for_analysis"
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b",
+        "${var.region}c"
+    ]
+    depends_on = [
+        "aws_launch_configuration.lc_for_analysis_asg"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc_for_analysis_asg.id}"
+    max_size = 1
+    min_size = 1
+    desired_capacity = 1
+    load_balancers = [
+        "${var.environment}--elb-for-analysis"
+    ]
+}

--- a/terraform/analysis/socorro_role.sh
+++ b/terraform/analysis/socorro_role.sh
@@ -1,0 +1,1 @@
+../socorro_role.sh

--- a/terraform/analysis/variables.tf
+++ b/terraform/analysis/variables.tf
@@ -1,0 +1,1 @@
+../variables.tf

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,6 +5,7 @@ variable "secret_bucket" {}
 variable "subnets" {}
 variable "collector_cert" {}
 variable "webapp_cert" {}
+variable "analysis_cert" {}
 variable "ssh_key_file" {
     default = {
         us-west-2 = "socorro__us-west-2.pem"

--- a/terraform/wrapper.sh
+++ b/terraform/wrapper.sh
@@ -2,7 +2,7 @@
 # This script acts as a wrapper to Terraform.
 
 TFVARS="terraform.tfvars"
-ROLES=(admin buildbox collector consul elasticsearch postgres processor rabbitmq symbolapi webapp)
+ROLES=(admin analysis buildbox collector consul elasticsearch postgres processor rabbitmq symbolapi webapp)
 HELPARGS=("help" "-help" "--help" "-h" "-?")
 
 function help {


### PR DESCRIPTION
r? @phrawzty @jdotpz - I think this is the most straightforward config right now for an EC2 instance running just Nginx.

The puppet bit seems pretty reasonable, but we really need to cut down on the amount of terraform config needed :)