### PR TITLE
nginx should not start until socorro package is in place

### DIFF
--- a/puppet/modules/socorro/manifests/role/collector.pp
+++ b/puppet/modules/socorro/manifests/role/collector.pp
@@ -31,7 +31,8 @@ include socorro::role::common
       ensure=> latest;
 
     'nginx':
-      ensure=> latest;
+      ensure=> latest,
+      require => Package['socorro'];
   }
 
 }

--- a/puppet/modules/socorro/manifests/role/webapp.pp
+++ b/puppet/modules/socorro/manifests/role/webapp.pp
@@ -31,7 +31,8 @@ include socorro::role::common
       ensure=> latest;
 
     'nginx':
-      ensure=> latest;
+      ensure=> latest,
+      require => Package['socorro'];
   }
 
 }


### PR DESCRIPTION
r? @jdotpz the Socorro RPM drops some nginx configs into ```/etc/nginx/conf.d```

Eventually we're going to have to override this in a smarter way (to drop the real hostname into ```server_name```) but for now this will get this going.