### PR TITLE
Consul running before join

### DIFF
--- a/puppet/modules/socorro/manifests/role/common.pp
+++ b/puppet/modules/socorro/manifests/role/common.pp
@@ -5,7 +5,8 @@ class socorro::role::common {
   $consul_hostname = hiera("${::environment}/consul_hostname")
   exec {
       'join_consul_cluster':
-        command => "/usr/bin/consul join ${consul_hostname}"
+        command => "/usr/bin/consul join ${consul_hostname}",
+        require => Service['consul']
   }
 
 }

--- a/puppet/modules/socorro/manifests/role/consul.pp
+++ b/puppet/modules/socorro/manifests/role/consul.pp
@@ -1,6 +1,6 @@
 # Set up a Consul Server node.
 
-include socorro::role::common
+class socorro::role::consul {
 
   service {
     'consul':

--- a/puppet/modules/socorro/manifests/role/consul.pp
+++ b/puppet/modules/socorro/manifests/role/consul.pp
@@ -1,5 +1,4 @@
 # Set up a Consul Server node.
-class socorro::role::consul {
 
 include socorro::role::common
 
@@ -25,6 +24,15 @@ include socorro::role::common
       group   => 'consul',
       mode    => '0640',
       require => Package['consul-ui'];
+  }
+
+  # We expect this to come from the secret S3 bucket
+  # This is here instead of common.pp so we can depend on server.json
+  $consul_hostname = hiera("${::environment}/consul_hostname")
+  exec {
+      'join_consul_cluster':
+        command => "/usr/bin/consul join ${consul_hostname}",
+        require => File['/etc/consul/server.json']
   }
 
 }


### PR DESCRIPTION
Normal nodes need to have consul agent running before trying `consul join`, and consul agent must be running in server mode on consul servers.