### PR TITLE
bug 1155524 - terraform should be able to make launch config changes wit...

### DIFF
--- a/terraform/admin/main.tf
+++ b/terraform/admin/main.tf
@@ -24,7 +24,6 @@ resource "aws_security_group" "ec2-socorroadmin-sg" {
 
 # Admin (crontabber, etc)
 resource "aws_launch_configuration" "lc-socorroadmin" {
-    name = "lc-${var.environment}-socorroadmin"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} admin ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
@@ -34,6 +33,9 @@ resource "aws_launch_configuration" "lc-socorroadmin" {
     security_groups = [
         "${aws_security_group.ec2-socorroadmin-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-socorroadmin" {

--- a/terraform/analysis/main.tf
+++ b/terraform/analysis/main.tf
@@ -69,7 +69,6 @@ resource "aws_elb" "elb-socorroanalysis" {
 }
 
 resource "aws_launch_configuration" "lc-socorroanalysis" {
-    name = "lc-${var.environment}-socorroanalysis"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} analysis ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
@@ -79,6 +78,9 @@ resource "aws_launch_configuration" "lc-socorroanalysis" {
     security_groups = [
         "${aws_security_group.ec2-socorroanalysis-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-socorroanalysis" {

--- a/terraform/buildbox/main.tf
+++ b/terraform/buildbox/main.tf
@@ -48,7 +48,6 @@ resource "aws_elb" "elb-socorrobuildbox" {
 }
 
 resource "aws_launch_configuration" "lc-socorrobuildbox" {
-    name = "lc-${var.environment}-socorrobuildbox"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} buildbox ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.buildbox_ami, var.region)}"
     instance_type = "t2.micro"
@@ -58,6 +57,9 @@ resource "aws_launch_configuration" "lc-socorrobuildbox" {
     security_groups = [
         "${aws_security_group.ec2-socorrobuildbox-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-socorrobuildbox" {

--- a/terraform/collector/main.tf
+++ b/terraform/collector/main.tf
@@ -60,7 +60,6 @@ resource "aws_elb" "elb-collector" {
 }
 
 resource "aws_launch_configuration" "lc-collector" {
-    name = "lc-${var.environment}-collector"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} collector ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
@@ -70,6 +69,9 @@ resource "aws_launch_configuration" "lc-collector" {
     security_groups = [
         "${aws_security_group.ec2-collector-sg.id}",
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-collector" {

--- a/terraform/consul/main.tf
+++ b/terraform/consul/main.tf
@@ -93,7 +93,6 @@ resource "aws_elb" "elb-consul" {
 }
 
 resource "aws_launch_configuration" "lc-consul" {
-    name = "lc-${var.environment}-consul"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} consul ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
@@ -103,6 +102,9 @@ resource "aws_launch_configuration" "lc-consul" {
     security_groups = [
         "${aws_security_group.ec2-consul-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-consul" {

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -69,7 +69,6 @@ resource "aws_elb" "elb-socorroelasticsearch" {
 }
 
 resource "aws_launch_configuration" "lc-socorroelasticsearch" {
-    name = "lc-${var.environment}-socorroelasticsearch"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} elasticsearch ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
@@ -79,6 +78,9 @@ resource "aws_launch_configuration" "lc-socorroelasticsearch" {
     security_groups = [
         "${aws_security_group.ec2-socorroelasticsearch-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-socorroelasticsearch" {

--- a/terraform/processor/main.tf
+++ b/terraform/processor/main.tf
@@ -23,7 +23,6 @@ resource "aws_security_group" "ec2-processor-sg" {
 }
 
 resource "aws_launch_configuration" "lc-processor" {
-    name = "lc-${var.environment}-processor"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} processor ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "r3.large"
@@ -33,6 +32,9 @@ resource "aws_launch_configuration" "lc-processor" {
     security_groups = [
         "${aws_security_group.ec2-processor-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-processor" {

--- a/terraform/rabbitmq/main.tf
+++ b/terraform/rabbitmq/main.tf
@@ -61,7 +61,6 @@ resource "aws_elb" "elb-socorrorabbitmq" {
 }
 
 resource "aws_launch_configuration" "lc-socorrorabbitmq" {
-    name = "lc-${var.environment}-socorrorabbitmq"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} rabbitmq ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
@@ -74,6 +73,9 @@ resource "aws_launch_configuration" "lc-socorrorabbitmq" {
     security_groups = [
         "${aws_security_group.ec2-socorrorabbitmq-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-socorrorabbitmq" {

--- a/terraform/symbolapi/main.tf
+++ b/terraform/symbolapi/main.tf
@@ -54,7 +54,6 @@ resource "aws_elb" "elb-symbolapi" {
 }
 
 resource "aws_launch_configuration" "lc-symbolapi" {
-    name = "lc-${var.environment}-symbolapi"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} symbolapi ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "c4.xlarge"
@@ -64,6 +63,9 @@ resource "aws_launch_configuration" "lc-symbolapi" {
     security_groups = [
         "${aws_security_group.ec2-symbolapi-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-symbolapi" {

--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -56,7 +56,6 @@ resource "aws_elb" "elb-socorroweb" {
 }
 
 resource "aws_launch_configuration" "lc-socorroweb" {
-    name = "lc-${var.environment}-socorroweb"
     user_data = "${file(\"socorro_role.sh\")} ${var.puppet_archive} webapp ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
@@ -66,6 +65,9 @@ resource "aws_launch_configuration" "lc-socorroweb" {
     security_groups = [
         "${aws_security_group.ec2-socorroweb-sg.id}"
     ]
+    lifecycle {
+        create_before_destroy = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-socorroweb" {


### PR DESCRIPTION
...hout tearing out infra

r? @phrawzty @jdotpz - as discussed, the only way terraform supports this (per `#terraform-tool` on `irc.freenode.net`) is to:

* set `create_before_destroy = true` in `lifecycle` for the resource
* let terraform name the resource (otherwise the "create" step will fail on AWS due to duplicate name)

Unfortunately, launch configs don't seem to support tags, so the tradeoff here is that we have to look at an ASG in order to tell where a given LC belongs :/

I made sure both `terraform plan` and `terraform apply` works with this patch, for at least the processor role.