### PR TITLE
tests need to run with -e so any failed test causes non-0 exit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 sudo: no
 language: python
-before_install:
-  - gem install puppet puppet-lint
-  - pushd terraform; wget 'https://dl.bintray.com/mitchellh/terraform/terraform_0.4.0_linux_amd64.zip'; unzip -u terraform_0.4.0_linux_amd64.zip; popd
 
 install: false
 
 script:
-  - puppet-lint --with-filename --no-80chars-check --no-autoloader_layout-check --fail-on-warnings puppet/
-  - puppet parser validate `find puppet/ -name '*.pp'`
-  - find ./terraform -type d -maxdepth 1 | while read role; do pushd $role; ../terraform plan -var="environment=FAKE" -var="secret_key=FAKE" -var="access_key=FAKE" -var="subnets=FAKE" -var="secret_bucket=FAKE"; popd; done
+  - ./bin/test.sh

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+TFORM_VERSION="0.4.2_linux_amd64"
+
+gem install puppet puppet-lint
+puppet-lint --with-filename --no-80chars-check --no-autoloader_layout-check --fail-on-warnings puppet/
+puppet parser validate `find puppet/ -name '*.pp'`
+
+pushd terraform
+wget "https://dl.bintray.com/mitchellh/terraform/terraform_${TFORM_VERSION}.zip"
+unzip -u terraform_${TFORM_VERSION}.zip
+./wrapper.sh symlinks
+popd
+
+for role in $(find ./terraform/* -maxdepth 1 -type d); do
+    pushd $role
+    ../terraform plan -var="environment=FAKE" \
+                   -var="secret_key=FAKE" \
+                   -var="access_key=FAKE" \
+                   -var="subnets=FAKE" \
+                   -var="secret_bucket=FAKE" \
+                   -var="collector_cert=FAKE" \
+                   -var="analysis_cert=FAKE" \
+                   -var="webapp_cert=FAKE"
+    popd
+done


### PR DESCRIPTION
I noticed that our tests aren't actually failing the travis job, even though the tests are failing.

The way we have the test shoved into `.travis.yaml` is nigh unreadable, let's split it out.

r? @phrawzty @jdotpz 