### PR TITLE
add opt to generate symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ terraform.tfstate*
 *.swp
 *.plan
 *.log
+terraform/*/*.sh
+terraform/*/*.tf

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ terraform.tfstate*
 *.plan
 *.log
 terraform/*/*.sh
-terraform/*/*.tf
+terraform/*/variables.tf

--- a/terraform/wrapper.sh
+++ b/terraform/wrapper.sh
@@ -8,6 +8,7 @@ HELPARGS=("help" "-help" "--help" "-h" "-?")
 
 function help {
     echo "USAGE: ${0} <action> <environment> <role>"
+    echo "       ${0} [symlinks]"
     echo -n "Valid roles are: "
     local i
     for i in "${ROLES[@]}"; do
@@ -25,7 +26,7 @@ function contains_element () {
     return 1
 }
 
-function check_symlinks () {
+function check_symlinks {
     for i in ${SYMLINKS[@]}; do
         if [ ! -L $i ]; then
             ln -s ../$i $i
@@ -33,10 +34,26 @@ function check_symlinks () {
     done
 }
 
+function make_symlinks {
+    set -e
+    for i in ${ROLES[@]}; do
+        pushd $i > /dev/null
+        check_symlinks
+        popd > /dev/null
+    done
+    set +e
+}
+
 # Is this a cry for help?
 contains_element $1 "${HELPARGS[@]}"
 if [ $? -eq 0 ]; then
     help
+fi
+
+# Did we want to generate symlinks?
+if [ $1 == "symlinks" ]; then
+    make_symlinks
+    exit 0
 fi
 
 # All of the args are mandatory.


### PR DESCRIPTION
Passing `symlinks` to `wrapper.sh` will just generate all the symlinks and then exit.

We can use this in Travis, for example.

`r?` @rhelmer 