### PR TITLE
fix arg check

### DIFF
--- a/terraform/wrapper.sh
+++ b/terraform/wrapper.sh
@@ -46,7 +46,7 @@ function make_symlinks {
 
 # Is this a cry for help?
 contains_element $1 "${HELPARGS[@]}"
-if [ $? -eq 0 ]; then
+if [ "${1}x" == "x" ]; then
     help
 fi
 


### PR DESCRIPTION
Not passing args will actually show help and exit now. :man_with_gua_pi_mao: 