### PR TITLE
Healthcheck tuning, cross zone elb, missing tags, match elb<->as zones, max_size /\

### DIFF
--- a/terraform/admin/main.tf
+++ b/terraform/admin/main.tf
@@ -53,7 +53,7 @@ resource "aws_autoscaling_group" "as-socorroadmin" {
         "aws_launch_configuration.lc-socorroadmin"
     ]
     launch_configuration = "${aws_launch_configuration.lc-socorroadmin.id}"
-    max_size = 1
+    max_size = 10
     min_size = 1
     desired_capacity = 1
     tag {

--- a/terraform/analysis/main.tf
+++ b/terraform/analysis/main.tf
@@ -64,11 +64,19 @@ resource "aws_elb" "elb-socorroanalysis" {
     security_groups = [
         "${var.elb_master_web_sg_id}"
     ]
+    health_check {
+      healthy_threshold = 2
+      unhealthy_threshold = 2
+      timeout = 3
+      target = "TCP:80/"
+      interval = 12
+    }
     tags {
         Environment = "${var.environment}"
         role = "socorroanalysis"
         project = "socorro"
     }
+    cross_zone_load_balancing = true
 }
 
 resource "aws_launch_configuration" "lc-socorroanalysis" {
@@ -98,7 +106,7 @@ resource "aws_autoscaling_group" "as-socorroanalysis" {
         "aws_launch_configuration.lc-socorroanalysis"
     ]
     launch_configuration = "${aws_launch_configuration.lc-socorroanalysis.id}"
-    max_size = 1
+    max_size = 10
     min_size = 1
     desired_capacity = 1
     load_balancers = [

--- a/terraform/buildbox/main.tf
+++ b/terraform/buildbox/main.tf
@@ -37,7 +37,8 @@ resource "aws_elb" "elb-socorrobuildbox" {
     name = "elb-${var.environment}-socorrobuildbox"
     availability_zones = [
         "${var.region}a",
-        "${var.region}b"
+        "${var.region}b",
+        "${var.region}c"
     ]
     listener {
         instance_port = 8888
@@ -48,6 +49,7 @@ resource "aws_elb" "elb-socorrobuildbox" {
     security_groups = [
         "${aws_security_group.ec2-socorrobuildbox-sg.id}"
     ]
+    cross_zone_load_balancing = true
 }
 
 resource "aws_launch_configuration" "lc-socorrobuildbox" {
@@ -77,7 +79,7 @@ resource "aws_autoscaling_group" "as-socorrobuildbox" {
         "aws_launch_configuration.lc-socorrobuildbox"
     ]
     launch_configuration = "${aws_launch_configuration.lc-socorrobuildbox.id}"
-    max_size = 1
+    max_size = 10
     min_size = 1
     desired_capacity = 1
     load_balancers = [

--- a/terraform/processor/main.tf
+++ b/terraform/processor/main.tf
@@ -52,7 +52,7 @@ resource "aws_autoscaling_group" "as-processor" {
         "aws_launch_configuration.lc-processor"
     ]
     launch_configuration = "${aws_launch_configuration.lc-processor.id}"
-    max_size = 1
+    max_size = 10
     min_size = 1
     desired_capacity = 1
     tag {

--- a/terraform/symbolapi/main.tf
+++ b/terraform/symbolapi/main.tf
@@ -49,11 +49,19 @@ resource "aws_elb" "elb-symbolapi" {
     security_groups = [
         "${var.elb_master_web_sg_id}"
     ]
+    health_check {
+      healthy_threshold = 2
+      unhealthy_threshold = 2
+      timeout = 3
+      target = "TCP:8000/"
+      interval = 12
+    }
     tags {
         Environment = "${var.environment}"
         role = "symbolapi"
         project = "socorro"
     }
+    cross_zone_load_balancing = true
 }
 
 resource "aws_launch_configuration" "lc-symbolapi" {
@@ -83,7 +91,7 @@ resource "aws_autoscaling_group" "as-symbolapi" {
         "aws_launch_configuration.lc-symbolapi"
     ]
     launch_configuration = "${aws_launch_configuration.lc-symbolapi.id}"
-    max_size = 1
+    max_size = 10
     min_size = 1
     desired_capacity = 1
     load_balancers = [

--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -53,9 +53,22 @@ resource "aws_elb" "elb-socorroweb" {
         lb_protocol = "https"
         ssl_certificate_id = "${var.webapp_cert}"
     }
+    health_check {
+      healthy_threshold = 2
+      unhealthy_threshold = 2
+      timeout = 3
+      target = "TCP:80/"
+      interval = 12
+    }
     security_groups = [
         "${var.elb_master_web_sg_id}"
     ]
+    tags {
+        Environment = "${var.environment}"
+        role = "socorrowebapp"
+        project = "socorro"
+    }
+    cross_zone_load_balancing = true
 }
 
 resource "aws_launch_configuration" "lc-socorroweb" {


### PR DESCRIPTION
* Changes health checks to be more reasonable (will speed up the deploy)
* Adds some missing zones that AS groups scaled into but elbs didn't have them on
* Adds some missing tags
* Turns on cross zone balancing, which might not be what we want long term, but for stage at 1 instance, it might help.
* Makes AS groups max_size 10, to allow for room to scale in new deploys while keeping existing working infra