### PR TITLE
Change latest to installed for socorro packages

### DIFF
--- a/puppet/modules/socorro/manifests/role/admin.pp
+++ b/puppet/modules/socorro/manifests/role/admin.pp
@@ -5,7 +5,7 @@ include socorro::role::common
 
   package {
     'socorro':
-      ensure => latest
+      ensure => installed
   }
 
   file {

--- a/puppet/modules/socorro/manifests/role/collector.pp
+++ b/puppet/modules/socorro/manifests/role/collector.pp
@@ -28,7 +28,7 @@ include socorro::role::common
 
   package {
     'socorro':
-      ensure=> latest;
+      ensure=> installed;
 
     'nginx':
       ensure=> latest;

--- a/puppet/modules/socorro/manifests/role/elasticsearch.pp
+++ b/puppet/modules/socorro/manifests/role/elasticsearch.pp
@@ -18,7 +18,7 @@ include socorro::role::common
       ensure => latest;
 
     'socorro':
-      ensure => latest;
+      ensure => installed;
   }
 
 }

--- a/puppet/modules/socorro/manifests/role/postgres.pp
+++ b/puppet/modules/socorro/manifests/role/postgres.pp
@@ -18,7 +18,7 @@ include socorro::role::common
       ensure=> latest;
 
     'socorro':
-      ensure=> latest;
+      ensure=> installed;
   }
 
 }

--- a/puppet/modules/socorro/manifests/role/processor.pp
+++ b/puppet/modules/socorro/manifests/role/processor.pp
@@ -15,7 +15,7 @@ include socorro::role::common
 
   package {
     'socorro':
-      ensure=> latest;
+      ensure=> installed;
 
     'nginx':
       ensure=> latest;

--- a/puppet/modules/socorro/manifests/role/webapp.pp
+++ b/puppet/modules/socorro/manifests/role/webapp.pp
@@ -28,7 +28,7 @@ include socorro::role::common
 
   package {
     'socorro':
-      ensure=> latest;
+      ensure=> installed;
 
     'nginx':
       ensure=> latest;


### PR DESCRIPTION
This is meant to address this scenario:
* v1.0.1 is in production, v1.0.2 is in staging being tested/updated
* We scale in a new node into a production cluster
* The new production node has v1.0.1 baked in on instantiation
* Puppet runs on the new production node, upping it to v1.0.2 despite that not being cleared for prod

This will mean we will have to use a base AMI (currently used) for the build instead of querying the AWS API for the latest staging AMI.  Otherwise, it would not install the updated version while making an AMI for staging and eventual production.
