### PR TITLE
Back to secgroup-per-env/app combo

### DIFF
--- a/terraform/admin/main.tf
+++ b/terraform/admin/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "ec2-socorroadmin-sg" {
-    name = "ec2-socorroadmin-sg"
+    name = "ec2-socorroadmin-${var.environment}-sg"
     description = "Allow (alt) SSH to the Admin node."
     ingress {
         from_port = "${var.alt_ssh_port}"

--- a/terraform/analysis/main.tf
+++ b/terraform/analysis/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "ec2-socorroanalysis-sg" {
-    name = "ec2-socorroanalysis-sg"
+    name = "ec2-socorroanalysis-${var.environment}-sg"
     description = "Crashanalysis node."
     ingress {
         from_port = "${var.alt_ssh_port}"

--- a/terraform/buildbox/main.tf
+++ b/terraform/buildbox/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "ec2-socorrobuildbox-sg" {
-    name = "ec2-socorrobuildbox-sg"
+    name = "ec2-socorrobuildbox-${var.environment}-sg"
     description = "Buildbox for socorro"
     ingress {
         from_port = "${var.alt_ssh_port}"

--- a/terraform/collector/main.tf
+++ b/terraform/collector/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "ec2-collector-sg" {
-    name = "ec2-collector-sg"
+    name = "ec2-collector-${var.environment}-sg"
     description = "Security grup for ec2 as group for socorro collector."
     ingress {
         from_port = "${var.alt_ssh_port}"

--- a/terraform/consul/main.tf
+++ b/terraform/consul/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 
 # Source: https://consul.io/docs/agent/options.html
 resource "aws_security_group" "ec2-consul-sg" {
-    name = "ec2-consul-sg"
+    name = "ec2-consul-${var.environment}-sg"
     description = "Allow internal access to various Consul services."
     ingress {
         from_port = 8300

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "elb-socorroelasticsearch-sg" {
-    name = "elb-${var.environment}-socorroelasticsearch-sg"
+    name = "elb-socorroelasticsearch-${var.environment}-sg"
     description = "Allow internal access to Elasticsearch."
     ingress {
         from_port = 9200
@@ -34,7 +34,7 @@ resource "aws_security_group" "elb-socorroelasticsearch-sg" {
 }
 
 resource "aws_security_group" "ec2-socorroelasticsearch-sg" {
-    name = "ec2-${var.environment}-socorroelasticsearch-sg"
+    name = "ec2-socorroelasticsearch-${var.environment}-sg"
     description = "Allow (alt) SSH to the Elasticsearch node."
     ingress {
         from_port = "${var.alt_ssh_port}"

--- a/terraform/processor/main.tf
+++ b/terraform/processor/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "ec2-processor-sg" {
-    name = "ec2-processor-sg"
+    name = "ec2-processor-${var.environment}-sg"
     description = "Socorro processor security group."
     ingress {
         from_port = "${var.alt_ssh_port}"

--- a/terraform/rabbitmq/main.tf
+++ b/terraform/rabbitmq/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "elb-socorrorabbitmq-sg" {
-    name = "elb-socorrorabbitmq-sg"
+    name = "elb-socorrorabbitmq-${var.environment}-sg"
     description = "Allow internal access to RabbitMQ."
     ingress {
         from_port = 5672
@@ -26,7 +26,7 @@ resource "aws_security_group" "elb-socorrorabbitmq-sg" {
 }
 
 resource "aws_security_group" "ec2-socorrorabbitmq-sg" {
-    name = "ec2-socorrorabbitmq-sg"
+    name = "ec2-socorrorabbitmq-${var.environment}-sg"
     description = "EC2 security for rabbitmq."
     ingress {
         from_port = "${var.alt_ssh_port}"

--- a/terraform/symbolapi/main.tf
+++ b/terraform/symbolapi/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "ec2-symbolapi-sg" {
-    name = "ec2-symbolapi-sg"
+    name = "ec2-symbolapi-${var.environment}-sg"
     description = "SG for socorro symbolapi"
     ingress {
         from_port = "${var.alt_ssh_port}"

--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "ec2-socorroweb-sg" {
-    name = "ec2-socorroweb-sg"
+    name = "ec2-socorroweb-${var.environment}-sg"
     description = "Security group for socorro web app"
     ingress {
         from_port = "${var.alt_ssh_port}"


### PR DESCRIPTION
In retrospect, having one security group shared is less desirable than having the ability to spin up test/clone infrastructure in the same VPC without polluting statefiles with different VPC ids.

I'm running through the test applies for this now.