### PR TITLE
re-add missing SG

### DIFF
--- a/terraform/rabbitmq/main.tf
+++ b/terraform/rabbitmq/main.tf
@@ -71,11 +71,12 @@ resource "aws_launch_configuration" "lc-socorrorabbitmq" {
     image_id = "${lookup(var.base_ami, var.region)}"
     instance_type = "t2.micro"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
-    security_groups = [
-        "${aws_security_group.ec2-socorrorabbitmq-sg.id}"
-    ]
     iam_instance_profile = "generic"
     associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.elb-socorrorabbitmq-sg.id}",
+        "${aws_security_group.ec2-socorrorabbitmq-sg.id}"
+    ]
     lifecycle {
         create_before_destroy = true
     }


### PR DESCRIPTION
r? @jdotpz @phrawzty - this SG went missing, so the ELB couldn't reach our instance and would never go in service.

I rearranged things a little bit to make diffing against the ES `main.tf` easier.