### PR TITLE
return terraform exit code

### DIFF
--- a/terraform/wrapper.sh
+++ b/terraform/wrapper.sh
@@ -100,8 +100,11 @@ aws s3 sync --exclude="*" --include="terraform.tfstate" s3://${BUCKET}/tfstate/$
 # Run TF; if this errors out we need to keep going.
 set +e
 terraform $ACTION -var "environment=${ENV}"
+EXIT_CODE=$?
 set -e
 
 # Upload tfstate to S3.
 aws s3 sync --exclude="*" --include="terraform.tfstate" ./ s3://${BUCKET}/tfstate/${ENV}/${ROLE}/
 popd
+
+exit $EXIT_CODE


### PR DESCRIPTION
r? @jdotpz @phrawzty - this is causing the build automation to return false positives when terraform is in fact failing.