### PR TITLE
Add a way to manually re-trigger deploys with GITHASH

### DIFF
--- a/bin/lib/create_rpm.sh
+++ b/bin/lib/create_rpm.sh
@@ -25,7 +25,7 @@ function create_rpm() {
     # Find the rpm file we created
     NEWRPM=`ls -lart /data/socorro/socorro*.rpm|awk '{print $9}'`
     # Get the version of that socorro rpm so we log it nicely.
-    NEWSOCORROVERSION=`ls /home/centos/org.mozilla.crash-stats.packages-public/x86_64/socorro-*.rpm|tail -n1|sed 's/\// /g'|sed 's/\./ /g'|awk '{print $8}'`
+    NEWSOCORROVERSION=`ls -lart /home/centos/org.mozilla.crash-stats.packages-public/x86_64/socorro-*.rpm|tail -n1|sed 's/\// /g'|sed 's/\./ /g'|awk '{print $8}'`
     # Get a version-date tag to apply as a name to the AMI
     SOCORROAMINAME="${NEWSOCORROVERSION}-`date +%m%d%y`"
     if [ "$SKIPRPM" = "true" ];then


### PR DESCRIPTION
When a job fails on the terraform step, it's shameful to have to start all over again and do AMI build and version build.  Further, it's a PITA to manually copy in the payload to Jenkins.

Thus, this makes us able to setup jobs in Jenkins, which you can manually run, supply an github commit hash, and it will then replace the environments AMI's and swap out nodes.