### PR TITLE
Take advantage of a few new wins in terraform v0.5.0

### DIFF
--- a/terraform/analysis/main.tf
+++ b/terraform/analysis/main.tf
@@ -77,6 +77,8 @@ resource "aws_elb" "elb-socorroanalysis" {
         project = "socorro"
     }
     cross_zone_load_balancing = true
+    connection_draining = true
+    connection_draining_timeout = 30
 }
 
 resource "aws_launch_configuration" "lc-socorroanalysis" {

--- a/terraform/buildbox/main.tf
+++ b/terraform/buildbox/main.tf
@@ -72,6 +72,8 @@ resource "aws_elb" "elb-socorrobuildbox" {
         "${aws_security_group.elb-socorrobuildbox-sg.id}"
     ]
     cross_zone_load_balancing = true
+    connection_draining = true
+    connection_draining_timeout = 30
 }
 
 resource "aws_launch_configuration" "lc-socorrobuildbox" {

--- a/terraform/collector/main.tf
+++ b/terraform/collector/main.tf
@@ -69,6 +69,8 @@ resource "aws_elb" "elb-collector" {
         project = "socorro"
     }
     cross_zone_load_balancing = true
+    connection_draining = true
+    connection_draining_timeout = 30
 }
 
 resource "aws_launch_configuration" "lc-collector" {

--- a/terraform/symbolapi/main.tf
+++ b/terraform/symbolapi/main.tf
@@ -62,6 +62,8 @@ resource "aws_elb" "elb-symbolapi" {
         project = "socorro"
     }
     cross_zone_load_balancing = true
+    connection_draining = true
+    connection_draining_timeout = 30
 }
 
 resource "aws_launch_configuration" "lc-symbolapi" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,6 +15,9 @@ variable "ssh_key_file" {
 variable "region" {
     default = "us-west-2"
 }
+variable "max_retries" {
+    default = 5
+}
 variable "ssh_key_name" {
     default = {
         us-west-2 = "socorro__us-west-2"

--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -106,6 +106,8 @@ resource "aws_elb" "elb-socorroweb" {
         project = "socorro"
     }
     cross_zone_load_balancing = true
+    connection_draining = true
+    connection_draining_timeout = 30
 }
 
 resource "aws_launch_configuration" "lc-socorroweb" {


### PR DESCRIPTION
* Allow terraform to retry 5 times after transient AWS api errors
* Enable 30 second timeout connection draining on our elbs