### PR TITLE
bug 1146447 - re-join the consul cluster when restarting in server mode

### DIFF
--- a/puppet/modules/socorro/manifests/role/consul.pp
+++ b/puppet/modules/socorro/manifests/role/consul.pp
@@ -18,4 +18,12 @@ include socorro::role::common
       mode   => '0640';
   }
 
+  # We expect this to come from the secret S3 bucket
+  $consul_hostname = hiera("${::environment}/consul_hostname")
+  exec {
+    'join_consul_server_cluster':
+      command  => "/usr/bin/consul join ${consul_hostname}",
+      requires => Service['consul'];
+  }
+
 }


### PR DESCRIPTION
r? @phrawzty / @jdotpz 

The problem with consul servers right now is that they do `consul join` before restarting in server mode, which causes them to leave the cluster.

They need to do a `consul join` after restarting in server mode, and consul should come up automagically.