### PR TITLE
Wait longer to scale down

### DIFF
--- a/bin/jenkins/update-infrastructure.sh
+++ b/bin/jenkins/update-infrastructure.sh
@@ -81,7 +81,7 @@ function create_scaling_trigger_and_policy() {
         --metric-name CPUUtilization \
         --namespace "AWS/EC2" \
         --period 300 \
-        --evaluation-periods 1 \
+        --evaluation-periods 3 \
         --threshold ${SCALEDOWNTHRESHOLD} \
         --statistic Average \
         --comparison-operator LessThanThreshold \


### PR DESCRIPTION
To help ensure we don't have autoscaling groups scaling down during a push, this changes the low cpu alert in cloudwatch for a given as group to wait for 3 periods of 5 minutes instead of just 5 minutes.