### PR TITLE
nobug; set hostname to ec2_instance_id, etc.

### DIFF
--- a/puppet/modules/socorro/manifests/packer/base.pp
+++ b/puppet/modules/socorro/manifests/packer/base.pp
@@ -178,11 +178,22 @@ class socorro::packer::base {
       mode   => '0644'
   }
 
+  # This little script is used to quickly pull out EC2 metadata via CLI.
+  # TODO: Package it properly.
   exec {
     'install-ec2-metadata':
-      path    => '/usr/bin',
-      command => '/bin/wget http://s3.amazonaws.com/ec2metadata/ec2-metadata -P /bin/ && /usr/bin/chmod 755 /bin/ec2-metadata',
-      creates => '/bin/ec2-metadata',
-      require => Package['wget']
+      path    => '/bin',
+      cwd     => '/bin',
+      command => 'curl -O https://s3.amazonaws.com/ec2metadata/ec2-metadata',
+      creates => '/bin/ec2-metadata'
   }
+
+  file {
+    '/bin/ec2-metadata':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      require => Exec['install-ec2-metadata']
+  }
+
 }

--- a/puppet/modules/socorro/manifests/role/common.pp
+++ b/puppet/modules/socorro/manifests/role/common.pp
@@ -31,14 +31,14 @@ class socorro::role::common {
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
-      notify  => Service['rsyslog'];
+      notify  => Service['rsyslog'],
+      require => Exec['set-hostname']
   }
 
   service {
     'rsyslog':
-      ensure  => running,
-      enable  => true,
-      require => Exec['set-hostname']
+      ensure => running,
+      enable => true
   }
 
 }


### PR DESCRIPTION
This addresses some concerns with #122:
* The Instance ID is a fact (`ec2_instance_id`) so we don't need a script to obtain it.
* The hostname needs to be set *before* we start sending logs upstream.
* The `ec2-metadata` script is now obtained over HTTPS instead of cleartext.
* Introduced a more canonical usage of Puppet in general.

I tagged this as DO NOT MERGE for now because I'm not sure if we want to bother with the `ec2-metadata` script at all (it appears to only be used in the context of setting the hostname).  I'll remove the related resources if we don't actually need the script.

`r?` @rhelmer @jdotpz 