### PR TITLE
extend ES support; roles, etc

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -14,17 +14,19 @@ unzip -u terraform_${TFORM_VERSION}.zip
 ./wrapper.sh symlinks
 popd
 
-for role in $(find ./terraform/* -maxdepth 1 -type d); do
-    pushd $role
-    ../terraform plan -var="environment=FAKE" \
-                   -var="secret_key=FAKE" \
-                   -var="access_key=FAKE" \
-                   -var="subnets=FAKE" \
-                   -var="secret_bucket=FAKE" \
-                   -var="collector_cert=FAKE" \
-                   -var="analysis_cert=FAKE" \
-                   -var="buildbox_cert=FAKE" \
-                   -var="webapp_cert=FAKE" \
-                   -var="rds_root_password=FAKE"
-    popd
+for environment in stage prod; do
+    for role in $(find ./terraform/* -maxdepth 1 -type d); do
+        pushd "$role"
+        ../terraform plan -var="environment=$environment" \
+                       -var="secret_key=FAKE" \
+                       -var="access_key=FAKE" \
+                       -var="subnets=FAKE" \
+                       -var="secret_bucket=FAKE" \
+                       -var="collector_cert=FAKE" \
+                       -var="analysis_cert=FAKE" \
+                       -var="buildbox_cert=FAKE" \
+                       -var="webapp_cert=FAKE" \
+                       -var="rds_root_password=FAKE"
+        popd
+    done
 done

--- a/puppet/modules/socorro/files/etc_security_limits.d/90-elasticsearch.conf
+++ b/puppet/modules/socorro/files/etc_security_limits.d/90-elasticsearch.conf
@@ -1,0 +1,3 @@
+# https://www.google.com/search?q=elasticsearch+too+many+open+files
+elasticsearch soft nofile 65535
+elasticsearch hard nofile 65535

--- a/puppet/modules/socorro/manifests/packer/base.pp
+++ b/puppet/modules/socorro/manifests/packer/base.pp
@@ -43,7 +43,7 @@ class socorro::packer::base {
     [
       'bind-utils',
       'consul-ui',
-      'java-1.7.0-openjdk',
+      'java-1.8.0-openjdk',
       'mod_wsgi',
       'nginx',
       'php-cli',
@@ -75,8 +75,14 @@ class socorro::packer::base {
       ensure  => latest,
       require => [
         Yumrepo['elasticsearch'],
-        Package['java-1.7.0-openjdk']
+        Package['java-1.8.0-openjdk']
       ]
+  }
+
+  package {
+    'elasticsearch-plugin-cloud-aws':
+      ensure  => latest,
+      require => Package['elasticsearch']
   }
 
   file {

--- a/puppet/modules/socorro/manifests/packer/buildbox.pp
+++ b/puppet/modules/socorro/manifests/packer/buildbox.pp
@@ -29,7 +29,6 @@ class socorro::packer::buildbox {
       'subversion',
       'time',
       'vim-enhanced',
-      'wget'
     ]:
     ensure  => latest,
     require => Package['epel-release', 'yum-plugin-fastestmirror']

--- a/puppet/modules/socorro/manifests/role/elasticsearch.pp
+++ b/puppet/modules/socorro/manifests/role/elasticsearch.pp
@@ -3,10 +3,45 @@ class socorro::role::elasticsearch {
 
 include socorro::role::common
 
+  # ES will hit default ulimits rather quickly.
+  file { '/etc/security/limits.d/90-elasticsearch.conf':
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/socorro/etc_security_limits.d/90-elasticsearch.conf'
+  }
+
+  # These switches determine the role of the node: master, interface, or data.
+  $es_master = $::elasticsearch_role ? {
+    'master' => true,
+    default  => false
+  }
+  $es_interface = $::elasticsearch_role ? {
+    'interface' => true,
+    default     => false
+  }
+  $es_data = $::elasticsearch_role ? {
+    'data'  => true,
+    default => false
+  }
+
+  # The values from the switches above are applied in elasticsearch.yml .
+  file { '/etc/elasticsearch/elasticsearch.yml':
+    owner   => 'root',
+    group   => 'elasticsearch',
+    mode    => '0644',
+    content => template('socorro/etc_elasticsearch/elasticsearch.yml.erb')
+  }
+
   service {
     'elasticsearch':
       ensure  => running,
       enable  => true,
-      require => Exec['join_consul_cluster'];
+      require => [
+        Exec['join_consul_cluster'],
+        File['/etc/security/limits.d/90-elasticsearch.conf'],
+        File['/etc/elasticsearch/elasticsearch.yml']
+      ]
   }
+
 }

--- a/puppet/modules/socorro/templates/etc_elasticsearch/elasticsearch.yml.erb
+++ b/puppet/modules/socorro/templates/etc_elasticsearch/elasticsearch.yml.erb
@@ -1,0 +1,25 @@
+---
+name: "<%= @ec2_instance_id %>"
+cluster:
+    name: "sss_<%= @environment %>"
+discovery:
+    zen:
+        minimum_master_hosts: 2
+    type: "ec2"
+    ec2:
+        tag:
+            Environment: "<%= @environment %>"
+            role: "elasticsearch"
+index:
+    number_of_replicas: 1
+action:
+    disable_shutdown: true
+    disable_delete_all_indices: true
+cloud:
+    aws:
+        region: "<%= @ec2_placement_availability_zone.chop %>"
+node:
+    master: <%= @es_master %>
+    data: <%= @es_data %>
+http:
+    enabled: <%= @es_interface %>

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -4,9 +4,46 @@ provider "aws" {
     secret_key = "${var.secret_key}"
 }
 
-resource "aws_security_group" "elb-socorroelasticsearch-sg" {
-    name = "elb-socorroelasticsearch-${var.environment}-sg"
-    description = "Allow internal access to Elasticsearch."
+resource "aws_security_group" "elb-socorroelasticsearch2-sg" {
+    name = "elb-socorroelasticsearch2-${var.environment}-sg"
+    description = "Allow ELB access to Elasticsearch."
+    ingress {
+        from_port = 9200
+        to_port = 9200
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    egress {
+        from_port = 0
+        to_port = 65535
+        protocol = "tcp"
+        cidr_blocks = [
+            "0.0.0.0/0"
+        ]
+    }
+    lifecycle {
+        create_before_destroy = true
+    }
+    tags {
+        Environment = "${var.environment}"
+        role = "elasticsearch"
+        project = "socorro"
+    }
+}
+
+resource "aws_security_group" "ec2-socorroelasticsearch2-sg" {
+    name = "ec2-socorroelasticsearch2-${var.environment}-sg"
+    description = "Allow internal access to ES, etc."
+    ingress {
+        from_port = "${var.alt_ssh_port}"
+        to_port = "${var.alt_ssh_port}"
+        protocol = "tcp"
+        cidr_blocks = [
+            "0.0.0.0/0"
+        ]
+    }
     ingress {
         from_port = 9200
         to_port = 9200
@@ -23,41 +60,12 @@ resource "aws_security_group" "elb-socorroelasticsearch-sg" {
             "172.31.0.0/16"
         ]
     }
-    egress {
-        from_port = 0
-        to_port = 65535
-        protocol = "tcp"
-        cidr_blocks = [
-            "0.0.0.0/0"
-        ]
-    }
-    egress {
-        from_port = 1514
-        to_port = 1514
-        protocol = "udp"
-        cidr_blocks = [
-            "0.0.0.0/0"
-        ]
-    }
-    lifecycle {
-        create_before_destroy = true
-    }
-    tags {
-        Environment = "${var.environment}"
-        role = "elasticsearch"
-        project = "socorro"
-    }
-}
-
-resource "aws_security_group" "ec2-socorroelasticsearch-sg" {
-    name = "ec2-socorroelasticsearch-${var.environment}-sg"
-    description = "Allow (alt) SSH to the Elasticsearch node."
     ingress {
-        from_port = "${var.alt_ssh_port}"
-        to_port = "${var.alt_ssh_port}"
+        from_port = 9200
+        to_port = 9200
         protocol = "tcp"
-        cidr_blocks = [
-            "0.0.0.0/0"
+        security_groups = [
+            "${aws_security_group.elb-socorroelasticsearch2-sg.id}"
         ]
     }
     egress {
@@ -86,8 +94,8 @@ resource "aws_security_group" "ec2-socorroelasticsearch-sg" {
     }
 }
 
-resource "aws_elb" "elb-socorroelasticsearch" {
-    name = "elb-${var.environment}-socorroelasticsearch"
+resource "aws_elb" "elb-socorroelasticsearch2" {
+    name = "elb-${var.environment}-socorroelasticsearch2"
     internal = true
     subnets = ["${split(",", var.subnets)}"]
     listener {
@@ -97,7 +105,7 @@ resource "aws_elb" "elb-socorroelasticsearch" {
         lb_protocol = "http"
     }
     security_groups = [
-        "${aws_security_group.elb-socorroelasticsearch-sg.id}"
+        "${aws_security_group.elb-socorroelasticsearch2-sg.id}"
     ]
     tags {
         Environment = "${var.environment}"
@@ -106,24 +114,53 @@ resource "aws_elb" "elb-socorroelasticsearch" {
     }
 }
 
-resource "aws_launch_configuration" "lc-socorroelasticsearch" {
-    user_data = "${file(\"socorro_role.sh\")} elasticsearch ${var.secret_bucket} ${var.environment}"
+resource "aws_launch_configuration" "lc-socorroelasticsearch2-master" {
+    user_data = "${file(\"socorro_role.sh\")} 'elasticsearch FACTER_elasticsearch_role=master' ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "t2.micro"
+    instance_type = "${lookup(var.es_master_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
-    iam_instance_profile = "generic"
+    iam_instance_profile = "socorro_elasticsearch"
     associate_public_ip_address = true
     security_groups = [
-        "${aws_security_group.elb-socorroelasticsearch-sg.id}",
-        "${aws_security_group.ec2-socorroelasticsearch-sg.id}"
+        "${aws_security_group.ec2-socorroelasticsearch2-sg.id}"
     ]
     lifecycle {
         create_before_destroy = true
     }
 }
 
-resource "aws_autoscaling_group" "as-socorroelasticsearch" {
-    name = "as-${var.environment}-socorroelasticsearch"
+resource "aws_launch_configuration" "lc-socorroelasticsearch2-interface" {
+    user_data = "${file(\"socorro_role.sh\")} 'elasticsearch FACTER_elasticsearch_role=interface' ${var.secret_bucket} ${var.environment}"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "${lookup(var.es_interface_ec2_type, var.environment)}"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    iam_instance_profile = "socorro_elasticsearch"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.ec2-socorroelasticsearch2-sg.id}"
+    ]
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+
+resource "aws_launch_configuration" "lc-socorroelasticsearch2-data" {
+    user_data = "${file(\"socorro_role.sh\")} 'elasticsearch FACTER_elasticsearch_role=data' ${var.secret_bucket} ${var.environment}"
+    image_id = "${lookup(var.base_ami, var.region)}"
+    instance_type = "${lookup(var.es_data_ec2_type, var.environment)}"
+    key_name = "${lookup(var.ssh_key_name, var.region)}"
+    iam_instance_profile = "socorro_elasticsearch"
+    associate_public_ip_address = true
+    security_groups = [
+        "${aws_security_group.ec2-socorroelasticsearch2-sg.id}"
+    ]
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+
+resource "aws_autoscaling_group" "as-socorroelasticsearch2-master" {
+    name = "as-${var.environment}-socorroelasticsearch2-master"
     availability_zones = [
         "${var.region}a",
         "${var.region}b",
@@ -131,15 +168,79 @@ resource "aws_autoscaling_group" "as-socorroelasticsearch" {
     ]
     vpc_zone_identifier = ["${split(",", var.subnets)}"]
     depends_on = [
-        "aws_launch_configuration.lc-socorroelasticsearch"
+        "aws_launch_configuration.lc-socorroelasticsearch2-master"
     ]
-    launch_configuration = "${aws_launch_configuration.lc-socorroelasticsearch.id}"
-    max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    launch_configuration = "${aws_launch_configuration.lc-socorroelasticsearch2-master.id}"
+    max_size = "${lookup(var.es_master_num, var.environment)}"
+    min_size = "${lookup(var.es_master_num, var.environment)}"
+    desired_capacity = "${lookup(var.es_master_num, var.environment)}"
+    tag {
+      key = "Environment"
+      value = "${var.environment}"
+      propagate_at_launch = true
+    }
+    tag {
+      key = "role"
+      value = "elasticsearch"
+      propagate_at_launch = true
+    }
+    tag {
+      key = "project"
+      value = "socorro"
+      propagate_at_launch = true
+    }
+}
+
+resource "aws_autoscaling_group" "as-socorroelasticsearch2-interface" {
+    name = "as-${var.environment}-socorroelasticsearch2-interface"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b",
+        "${var.region}c"
+    ]
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
+    depends_on = [
+        "aws_launch_configuration.lc-socorroelasticsearch2-interface"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc-socorroelasticsearch2-interface.id}"
+    max_size = "${lookup(var.es_interface_num, var.environment)}"
+    min_size = "${lookup(var.es_interface_num, var.environment)}"
+    desired_capacity = "${lookup(var.es_interface_num, var.environment)}"
     load_balancers = [
-        "elb-${var.environment}-socorroelasticsearch"
+        "elb-${var.environment}-socorroelasticsearch2"
     ]
+    tag {
+      key = "Environment"
+      value = "${var.environment}"
+      propagate_at_launch = true
+    }
+    tag {
+      key = "role"
+      value = "elasticsearch"
+      propagate_at_launch = true
+    }
+    tag {
+      key = "project"
+      value = "socorro"
+      propagate_at_launch = true
+    }
+}
+
+resource "aws_autoscaling_group" "as-socorroelasticsearch2-data" {
+    name = "as-${var.environment}-socorroelasticsearch2-data"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b",
+        "${var.region}c"
+    ]
+    vpc_zone_identifier = ["${split(",", var.subnets)}"]
+    depends_on = [
+        "aws_launch_configuration.lc-socorroelasticsearch2-data"
+    ]
+    launch_configuration = "${aws_launch_configuration.lc-socorroelasticsearch2-data.id}"
+    max_size = "${lookup(var.es_data_num, var.environment)}"
+    min_size = "${lookup(var.es_data_num, var.environment)}"
+    desired_capacity = "${lookup(var.es_data_num, var.environment)}"
     tag {
       key = "Environment"
       value = "${var.environment}"

--- a/terraform/elasticsearch/outputs.tf
+++ b/terraform/elasticsearch/outputs.tf
@@ -1,3 +1,3 @@
 output "private_addr__elasticsearch__http" {
-    value = "${aws_elb.elb-socorroelasticsearch2.dns_name}"
+    value = "${aws_elb.elb-socorroes.dns_name}"
 }

--- a/terraform/elasticsearch/outputs.tf
+++ b/terraform/elasticsearch/outputs.tf
@@ -1,3 +1,3 @@
 output "private_addr__elasticsearch__http" {
-    value = "${aws_elb.elb-socorroelasticsearch.dns_name}"
+    value = "${aws_elb.elb-socorroelasticsearch2.dns_name}"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,6 +40,44 @@ variable "elb_master_web_sg_id" {
 variable "alt_ssh_port" {
     default = 22123
 }
+# Start Elasticsearch block
+variable "es_master_ec2_type" {
+    default = {
+        stage = "t2.medium"
+        prod = "t2.medium"
+    }
+}
+variable "es_master_num" {
+    default = {
+        stage = "2"
+        prod = "3"
+    }
+}
+variable "es_interface_ec2_type" {
+    default = {
+        stage = "r3.large"
+        prod = "r3.xlarge"
+    }
+}
+variable "es_interface_num" {
+    default = {
+        stage = "2"
+        prod = "3"
+    }
+}
+variable "es_data_ec2_type" {
+    default = {
+        stage = "i2.xlarge"
+        prod = "i2.2xlarge"
+    }
+}
+variable "es_data_num" {
+    default = {
+        stage = "3"
+        prod = "9"
+    }
+}
+# End Elasticsearch block
 # NOTE - this deletes EBS devices, only change it for testing purposes!
 variable "del_on_term" {
     default = "false"


### PR DESCRIPTION
There are ASG and LC resource blocks for each of the three types of ES role (master, interface, and data, respectively). I had to pass this bit of information to userdata somehow, so I exploited the `socorro_role` positional argument to pass additional data (i.e. `'elasticsearch FACTER_elasticsearch_role=master'`). This is gross but it works for now. :unamused: 

As a side-effect, I appear to have proposed a model for splitting out values based on environment, as seen in `variables.tf`. It's functional and readable, so that's nice, but I'm not married to it.

Finally, I had to change the Terraform labels to `socorroelasticsearch2` so that the resources wouldn't collide with the existing `socorroelasticsearch` resources; before we merge, the latter resources will need to be removed entirely and the former will be renamed as appropriate.

I tested this against AMI ID `ami-2fe2df1f` (built from this branch) and the nodes came up, ES started, discovery occurred, and the cluster came up :green_apple: as expected.

It's also worth noting that this PR introduces another IAM role specific to Elasticsearch (for enabling auto-discovery). As we are not currently managing IAM via Terraform, the details of that role are not present in this PR - a conversation for another time, perhaps. :wink: 

This PR also satisfies [bug 1167134](https://bugzilla.mozilla.org/show_bug.cgi?id=1167134) by installing OpenJDK 1.8 in the Base AMI.

`r?` @rhelmer @jdotpz 