### PR TITLE
currently symbolapi does not use consul, if the cluster is unhealthy …

### DIFF
--- a/puppet/modules/socorro/manifests/role/symbolapi.pp
+++ b/puppet/modules/socorro/manifests/role/symbolapi.pp
@@ -5,9 +5,8 @@ include socorro::role::common
 
   service {
     'mozilla-snappy':
-      ensure  => running,
-      enable  => true,
-      require => Exec['join_consul_cluster'];
+      ensure => running,
+      enable => true
   }
 
 }


### PR DESCRIPTION
…then puppet apply fails for no useful reason

r? @phrawzty @jdotpz - I don't know that we'll ever really need to do any configuration here, this service is totally standalone and public (it provides an on-demand symbolication service to the Gecko Profiler, using the public S3 symbols bucket)