### PR TITLE
Roll new variable scaling standard out to all active node types (+ a modification)

### DIFF
--- a/bin/lib/identify_role.sh
+++ b/bin/lib/identify_role.sh
@@ -8,6 +8,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="true"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorroweb_num.stage"
             ;;
 
         collector-stage )
@@ -17,6 +18,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="true"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="collector_num.stage"
             ;;
 
         processor-stage )
@@ -26,6 +28,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="false"
+            SCALEVARIABLE="processor_num.stage"
             ;;
 
         socorroanalysis-stage )
@@ -35,6 +38,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorroanalysis_num.stage"
             ;;
 
         socorroadmin-stage )
@@ -44,6 +48,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="false"
+            SCALEVARIABLE="socorroadmin_num.stage"
             ;;
 
         symbolapi-stage )
@@ -53,6 +58,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="false"
+            SCALEVARIABLE="symbolapi_num.stage"
             ;;
 
         consul-stage )
@@ -62,6 +68,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorroconsul_num.stage"
             ;;
 
         socorrorabbitmq-stage )
@@ -71,6 +78,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorrorabbitmq_num.stage"
             ;;
 
         elasticsearch-stage )
@@ -80,6 +88,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="todo"
             ;;
 
         socorrobuildbox-stage )
@@ -89,6 +98,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorrobuildbox_num.stage"
             ;;
 
         socorroweb-prod )
@@ -98,6 +108,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorroweb_num.prod"
             ;;
 
         collector-prod )
@@ -107,6 +118,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="collector_num.prod"
             ;;
 
         processor-prod )
@@ -116,6 +128,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="false"
+            SCALEVARIABLE="processor_num.prod"
             ;;
 
         socorroanalysis-prod )
@@ -125,6 +138,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorroanalysis_num.prod"
             ;;
 
         socorroadmin-prod )
@@ -134,6 +148,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="false"
+            SCALEVARIABLE="socorroadmin_num.prod"
             ;;
 
         symbolapi-prod )
@@ -143,6 +158,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="symbolapi_num.prod"
             ;;
 
         consul-prod )
@@ -152,6 +168,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="consul_num.prod"
             ;;
 
         rabbitmq-prod )
@@ -161,6 +178,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorrorabbitmq_num.prod"
             ;;
 
         elasticsearch-prod )
@@ -170,6 +188,7 @@ function identify_role() {
             SSLELB="false"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="todo"
             ;;
 
         socorrobuildbox-prod )
@@ -179,6 +198,7 @@ function identify_role() {
             SSLELB="true"
             APPLYSCALINGPOLICY="false"
             NOTIFYFORUNHEALTHYELB="true"
+            SCALEVARIABLE="socorrobuildbox_num.prod"
             ;;
 
         * )

--- a/terraform/admin/main.tf
+++ b/terraform/admin/main.tf
@@ -45,7 +45,7 @@ resource "aws_security_group" "ec2-socorroadmin-sg" {
 resource "aws_launch_configuration" "lc-socorroadmin" {
     user_data = "${file(\"socorro_role.sh\")} admin ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "t2.micro"
+    instance_type = "${lookup(var.socorroadmin_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     iam_instance_profile = "generic"
     associate_public_ip_address = true
@@ -70,8 +70,8 @@ resource "aws_autoscaling_group" "as-socorroadmin" {
     ]
     launch_configuration = "${aws_launch_configuration.lc-socorroadmin.id}"
     max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    min_size = "${lookup(var.socorroadmin_num, var.environment)}"
+    desired_capacity = "${lookup(var.socorroadmin_num, var.environment)}"
     tag {
       key = "Environment"
       value = "${var.environment}"

--- a/terraform/analysis/main.tf
+++ b/terraform/analysis/main.tf
@@ -100,7 +100,7 @@ resource "aws_elb" "elb-socorroanalysis" {
 resource "aws_launch_configuration" "lc-socorroanalysis" {
     user_data = "${file(\"socorro_role.sh\")} analysis ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "t2.micro"
+    instance_type = "${lookup(var.socorroanalysis_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     iam_instance_profile = "generic"
     associate_public_ip_address = true
@@ -124,9 +124,9 @@ resource "aws_autoscaling_group" "as-socorroanalysis" {
         "aws_launch_configuration.lc-socorroanalysis"
     ]
     launch_configuration = "${aws_launch_configuration.lc-socorroanalysis.id}"
-    max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    max_size = 30
+    min_size = "${lookup(var.socorroanalysis_num, var.environment)}"
+    desired_capacity = "${lookup(var.socorroanalysis_num, var.environment)}"
     load_balancers = [
         "elb-${var.environment}-socorroanalysis"
     ]

--- a/terraform/buildbox/main.tf
+++ b/terraform/buildbox/main.tf
@@ -111,7 +111,7 @@ resource "aws_elb" "elb-socorrobuildbox" {
 resource "aws_launch_configuration" "lc-socorrobuildbox" {
     user_data = "${file(\"socorro_role.sh\")} buildbox ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.buildbox_ami, var.region)}"
-    instance_type = "c3.large"
+    instance_type = "${lookup(var.socorrobuildbox_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     iam_instance_profile = "buildbox"
     associate_public_ip_address = true
@@ -136,8 +136,8 @@ resource "aws_autoscaling_group" "as-socorrobuildbox" {
     ]
     launch_configuration = "${aws_launch_configuration.lc-socorrobuildbox.id}"
     max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    min_size = "${lookup(var.socorrobuildbox_num, var.environment)}"
+    desired_capacity = "${lookup(var.socorrobuildbox_num, var.environment)}"
     load_balancers = [
         "elb-${var.environment}-socorrobuildbox"
     ]

--- a/terraform/collector/main.tf
+++ b/terraform/collector/main.tf
@@ -92,7 +92,7 @@ resource "aws_elb" "elb-collector" {
 resource "aws_launch_configuration" "lc-collector" {
     user_data = "${file(\"socorro_role.sh\")} collector ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "t2.micro"
+    instance_type = "${lookup(var.collector_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     iam_instance_profile = "generic"
     associate_public_ip_address = true
@@ -116,9 +116,9 @@ resource "aws_autoscaling_group" "as-collector" {
         "aws_launch_configuration.lc-collector"
     ]
     launch_configuration = "${aws_launch_configuration.lc-collector.id}"
-    max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    max_size = 30
+    min_size = "${lookup(var.collector_num, var.environment)}"
+    desired_capacity = "${lookup(var.collector_num, var.environment)}"
     load_balancers = [
         "elb-${var.environment}-collector"
     ]

--- a/terraform/consul/main.tf
+++ b/terraform/consul/main.tf
@@ -114,7 +114,7 @@ resource "aws_elb" "elb-consul" {
 resource "aws_launch_configuration" "lc-consul" {
     user_data = "${file(\"socorro_role.sh\")} consul ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "t2.micro"
+    instance_type = "${lookup(var.socorroconsul_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     iam_instance_profile = "generic"
     associate_public_ip_address = true
@@ -138,9 +138,9 @@ resource "aws_autoscaling_group" "as-consul" {
         "aws_launch_configuration.lc-consul"
     ]
     launch_configuration = "${aws_launch_configuration.lc-consul.id}"
-    max_size = 3
-    min_size = 3
-    desired_capacity = 3
+    max_size = 30
+    min_size = "${lookup(var.socorroconsul_num, var.environment)}"
+    desired_capacity = "${lookup(var.socorroconsul_num, var.environment)}"
     health_check_type = "EC2"
     load_balancers = [
         "elb-${var.environment}-consul"

--- a/terraform/processor/main.tf
+++ b/terraform/processor/main.tf
@@ -44,7 +44,7 @@ resource "aws_security_group" "ec2-processor-sg" {
 resource "aws_launch_configuration" "lc-processor" {
     user_data = "${file(\"socorro_role.sh\")} processor ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "r3.large"
+    instance_type = "${lookup(var.processor_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     iam_instance_profile = "generic"
     associate_public_ip_address = true
@@ -68,9 +68,9 @@ resource "aws_autoscaling_group" "as-processor" {
         "aws_launch_configuration.lc-processor"
     ]
     launch_configuration = "${aws_launch_configuration.lc-processor.id}"
-    max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    max_size = 30
+    min_size = "${lookup(var.processor_num, var.environment)}"
+    desired_capacity = "${lookup(var.processor_num, var.environment)}"
     tag {
       key = "Environment"
       value = "${var.environment}"

--- a/terraform/rabbitmq/main.tf
+++ b/terraform/rabbitmq/main.tf
@@ -101,7 +101,7 @@ resource "aws_elb" "elb-socorrorabbitmq" {
 resource "aws_launch_configuration" "lc-socorrorabbitmq" {
     user_data = "${file(\"socorro_role.sh\")} rabbitmq ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "t2.micro"
+    instance_type = "${lookup(var.socorrorabbitmq_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     security_groups = [
         "${aws_security_group.ec2-socorrorabbitmq-sg.id}"
@@ -126,8 +126,8 @@ resource "aws_autoscaling_group" "as-socorrorabbitmq" {
     ]
     launch_configuration = "${aws_launch_configuration.lc-socorrorabbitmq.id}"
     max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    min_size = "${lookup(var.socorrorabbitmq_num, var.environment)}"
+    desired_capacity = "${lookup(var.socorrorabbitmq_num, var.environment)}"
     load_balancers = [
         "elb-${var.environment}-socorrorabbitmq"
     ]

--- a/terraform/symbolapi/main.tf
+++ b/terraform/symbolapi/main.tf
@@ -85,7 +85,7 @@ resource "aws_elb" "elb-symbolapi" {
 resource "aws_launch_configuration" "lc-symbolapi" {
     user_data = "${file(\"socorro_role.sh\")} symbolapi ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "c4.xlarge"
+    instance_type = "${lookup(var.symbolapi_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     iam_instance_profile = "generic"
     associate_public_ip_address = true
@@ -110,8 +110,8 @@ resource "aws_autoscaling_group" "as-symbolapi" {
     ]
     launch_configuration = "${aws_launch_configuration.lc-symbolapi.id}"
     max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    min_size = "${lookup(var.symbolapi_num, var.environment)}"
+    desired_capacity = "${lookup(var.symbolapi_num, var.environment)}"
     load_balancers = [
         "elb-${var.environment}-symbolapi"
     ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,6 +40,115 @@ variable "elb_master_web_sg_id" {
 variable "alt_ssh_port" {
     default = 22123
 }
+# Start App Tier scale type block
+variable "socorroadmin_num" {
+    default = {
+        stage = "1"
+        prod = "1"
+    }
+}
+variable "socorroadmin_ec2_type" {
+    default = {
+        stage = "t2.micro"
+        prod = "t2.micro"
+    }
+}
+variable "socorroanalysis_num" {
+    default = {
+        stage = "1"
+        prod = "1"
+    }
+}
+variable "socorroanalysis_ec2_type" {
+    default = {
+        stage = "t2.micro"
+        prod = "t2.micro"
+    }
+}
+variable "socorrobuildbox_num" {
+    default = {
+        stage = "1"
+        prod = "1"
+    }
+}
+variable "socorrobuildbox_ec2_type" {
+    default = {
+        stage = "c3.large"
+        prod = "c3.large"
+    }
+}
+variable "socorroconsul_num" {
+    default = {
+        stage = "3"
+        prod = "3"
+    }
+}
+variable "socorroconsul_ec2_type" {
+    default = {
+        stage = "t2.micro"
+        prod = "m3.medium"
+    }
+}
+variable "collector_num" {
+    default = {
+        stage = "1"
+        prod = "6"
+    }
+}
+variable "collector_ec2_type" {
+    default = {
+        stage = "t2.micro"
+        prod = "m3.medium"
+    }
+}
+variable "processor_num" {
+    default = {
+        stage = "1"
+        prod = "3"
+    }
+}
+variable "processor_ec2_type" {
+    default = {
+        stage = "r3.large"
+        prod = "r3.xlarge"
+    }
+}
+variable "socorrorabbitmq_num" {
+    default = {
+        stage = "1"
+        prod = "1"
+    }
+}
+variable "socorrorabbitmq_ec2_type" {
+    default = {
+        stage = "t2.micro"
+        prod = "m3.medium"
+    }
+}
+variable "symbolapi_num" {
+    default = {
+        stage = "1"
+        prod = "1"
+    }
+}
+variable "symbolapi_ec2_type" {
+    default = {
+        stage = "t2.micro"
+        prod = "r3.xlarge"
+    }
+}
+variable "socorroweb_num" {
+    default = {
+        stage = "1"
+        prod = "3"
+    }
+}
+variable "socorroweb_ec2_type" {
+    default = {
+        stage = "t2.micro"
+        prod = "m3.medium"
+    }
+}
 # Start Elasticsearch block
 variable "es_master_ec2_type" {
     default = {

--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -145,7 +145,7 @@ resource "aws_elb" "elb-socorroweb" {
 resource "aws_launch_configuration" "lc-socorroweb" {
     user_data = "${file(\"socorro_role.sh\")} webapp ${var.secret_bucket} ${var.environment}"
     image_id = "${lookup(var.base_ami, var.region)}"
-    instance_type = "t2.micro"
+    instance_type = "${lookup(var.socorroweb_ec2_type, var.environment)}"
     key_name = "${lookup(var.ssh_key_name, var.region)}"
     iam_instance_profile = "generic"
     associate_public_ip_address = true
@@ -170,8 +170,8 @@ resource "aws_autoscaling_group" "as-socorroweb" {
     ]
     launch_configuration = "${aws_launch_configuration.lc-socorroweb.id}"
     max_size = 10
-    min_size = 1
-    desired_capacity = 1
+    min_size = "${lookup(var.socorroweb_num, var.environment)}"
+    desired_capacity = "${lookup(var.socorroweb_num, var.environment)}"
     load_balancers = [
         "elb-${var.environment}-socorroweb"
     ]


### PR DESCRIPTION
## Highlights
* This PR applies @phrawzty 's new standard for scale variables to all other applicable node types (I didn't do the postgres nodes.)  
* It changes that standard a tiny bit with regards to max size management.
* Wait 15 times for the health checks to come back
* Deploy script now dabbles with min size to help stop losing nodes during longer deploys, and is cognizant of an apps current min_size when depoying.

## Changes to the previous standard
This also modifies https://github.com/mozilla/socorro-infra/pull/132#event-311899729 slightly.  The min/desired/max were all being set to the same variable.  Instead, I propose the following:

We make a semi-default max capacity; here, I chose 10 max for nodes we know won't really ever scale, and 30 for nodes that well...just might. I'm thinking if we need to change max, we'll need to do it on a more one-off basis, and can easily change the var in our repo per config file.

## Assumptions made
I took my instance type and counts from https://docs.google.com/spreadsheets/d/1TG0GSQK3RxoZCpy4DVOos5BomXZgD0LV0_L0dDrs7wQ/edit#gid=0 where we've specced out the first draft of what our infra will look like.

