### PR TITLE
bug 1118471; es data nodes

### DIFF
--- a/puppet/modules/socorro/manifests/role/elasticsearch.pp
+++ b/puppet/modules/socorro/manifests/role/elasticsearch.pp
@@ -4,11 +4,12 @@ class socorro::role::elasticsearch {
 include socorro::role::common
 
   # ES will hit default ulimits rather quickly.
-  file { '/etc/security/limits.d/90-elasticsearch.conf':
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
-    source => 'puppet:///modules/socorro/etc_security_limits.d/90-elasticsearch.conf'
+  file {
+    '/etc/security/limits.d/90-elasticsearch.conf':
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+      source => 'puppet:///modules/socorro/etc_security_limits.d/90-elasticsearch.conf'
   }
 
   # These switches determine the role of the node: master, interface, or data.
@@ -26,11 +27,17 @@ include socorro::role::common
   }
 
   # The values from the switches above are applied in elasticsearch.yml .
-  file { '/etc/elasticsearch/elasticsearch.yml':
-    owner   => 'root',
-    group   => 'elasticsearch',
-    mode    => '0644',
-    content => template('socorro/etc_elasticsearch/elasticsearch.yml.erb')
+  file {
+    '/etc/elasticsearch/elasticsearch.yml':
+      owner   => 'root',
+      group   => 'elasticsearch',
+      mode    => '0644',
+      content => template('socorro/etc_elasticsearch/elasticsearch.yml.erb')
+  }
+
+  file {
+    '/var/lib/elasticsearch':
+      owner => 'elasticsearch'
   }
 
   service {
@@ -40,8 +47,32 @@ include socorro::role::common
       require => [
         Exec['join_consul_cluster'],
         File['/etc/security/limits.d/90-elasticsearch.conf'],
-        File['/etc/elasticsearch/elasticsearch.yml']
+        File['/etc/elasticsearch/elasticsearch.yml'],
+        File['/var/lib/elasticsearch']
       ]
+  }
+
+  # Data nodes have an attached EBS volume that needs to be formatted and
+  # mounted before the service is activated.
+  if $::elasticsearch_role == 'data' {
+    exec {
+      'format-es-data':
+        path    => '/usr/sbin',
+        command => 'mkfs.ext4 /dev/xvdb'
+    }
+
+    mount {
+      '/var/lib/elasticsearch':
+        ensure  => mounted,
+        device  => '/dev/xvdb',
+        fstype  => 'ext4',
+        options => 'defaults',
+        require => Exec['format-es-data']
+    }
+
+    File['/var/lib/elasticsearch'] {
+      require => Mount['/var/lib/elasticsearch']
+    }
   }
 
 }

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -157,6 +157,12 @@ resource "aws_launch_configuration" "lc-socorroes-data" {
     lifecycle {
         create_before_destroy = true
     }
+    ebs_block_device {
+        device_name = "/dev/xvdb"
+        volume_type = "gp2"
+        volume_size = "${lookup(var.es_data_ebs_size, var.environment)}"
+        delete_on_termination = true
+    }
 }
 
 resource "aws_autoscaling_group" "as-socorroes-master" {
@@ -175,19 +181,19 @@ resource "aws_autoscaling_group" "as-socorroes-master" {
     min_size = "${lookup(var.es_master_num, var.environment)}"
     desired_capacity = "${lookup(var.es_master_num, var.environment)}"
     tag {
-      key = "Environment"
-      value = "${var.environment}"
-      propagate_at_launch = true
+        key = "Environment"
+        value = "${var.environment}"
+        propagate_at_launch = true
     }
     tag {
-      key = "role"
-      value = "elasticsearch"
-      propagate_at_launch = true
+        key = "role"
+        value = "elasticsearch"
+        propagate_at_launch = true
     }
     tag {
-      key = "project"
-      value = "socorro"
-      propagate_at_launch = true
+        key = "project"
+        value = "socorro"
+        propagate_at_launch = true
     }
 }
 
@@ -210,19 +216,19 @@ resource "aws_autoscaling_group" "as-socorroes-interface" {
         "elb-${var.environment}-socorroes"
     ]
     tag {
-      key = "Environment"
-      value = "${var.environment}"
-      propagate_at_launch = true
+        key = "Environment"
+        value = "${var.environment}"
+        propagate_at_launch = true
     }
     tag {
-      key = "role"
-      value = "elasticsearch"
-      propagate_at_launch = true
+        key = "role"
+        value = "elasticsearch"
+        propagate_at_launch = true
     }
     tag {
-      key = "project"
-      value = "socorro"
-      propagate_at_launch = true
+        key = "project"
+        value = "socorro"
+        propagate_at_launch = true
     }
 }
 
@@ -242,18 +248,18 @@ resource "aws_autoscaling_group" "as-socorroes-data" {
     min_size = "${lookup(var.es_data_num, var.environment)}"
     desired_capacity = "${lookup(var.es_data_num, var.environment)}"
     tag {
-      key = "Environment"
-      value = "${var.environment}"
-      propagate_at_launch = true
+        key = "Environment"
+        value = "${var.environment}"
+        propagate_at_launch = true
     }
     tag {
-      key = "role"
-      value = "elasticsearch"
-      propagate_at_launch = true
+        key = "role"
+        value = "elasticsearch"
+        propagate_at_launch = true
     }
     tag {
-      key = "project"
-      value = "socorro"
-      propagate_at_launch = true
+        key = "project"
+        value = "socorro"
+        propagate_at_launch = true
     }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,7 +49,7 @@ variable "es_master_ec2_type" {
 }
 variable "es_master_num" {
     default = {
-        stage = "2"
+        stage = "3"
         prod = "3"
     }
 }
@@ -67,14 +67,20 @@ variable "es_interface_num" {
 }
 variable "es_data_ec2_type" {
     default = {
-        stage = "i2.xlarge"
-        prod = "i2.2xlarge"
+        stage = "r3.xlarge"
+        prod = "r3.2xlarge"
     }
 }
 variable "es_data_num" {
     default = {
         stage = "3"
         prod = "9"
+    }
+}
+variable "es_data_ebs_size" {
+    default = {
+        stage = "100"
+        prod = "100"
     }
 }
 # End Elasticsearch block


### PR DESCRIPTION
This ensures that the ES Data nodes have an EBS volume available to them. This is done in two parts: in Terraform an `ebs_block_device` resource is added to the appropriate launch config, and in Puppet the volume is formatted and mounted before the ES service is activated.

I also made some style fixes in both Puppet and Terraform which are cosmetic (and make the PR look larger than it is).

`r?` @jdotpz @rhelmer