### PR TITLE
fix bug 1168723; allow Consul for all nodes

### DIFF
--- a/terraform/admin/main.tf
+++ b/terraform/admin/main.tf
@@ -31,6 +31,23 @@ resource "aws_security_group" "ec2-socorroadmin-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }

--- a/terraform/analysis/main.tf
+++ b/terraform/analysis/main.tf
@@ -47,6 +47,23 @@ resource "aws_security_group" "ec2-socorroanalysis-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }

--- a/terraform/buildbox/main.tf
+++ b/terraform/buildbox/main.tf
@@ -68,6 +68,23 @@ resource "aws_security_group" "ec2-socorrobuildbox-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }

--- a/terraform/collector/main.tf
+++ b/terraform/collector/main.tf
@@ -39,6 +39,23 @@ resource "aws_security_group" "ec2-collector-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -84,6 +84,23 @@ resource "aws_security_group" "ec2-socorroes-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }

--- a/terraform/processor/main.tf
+++ b/terraform/processor/main.tf
@@ -31,6 +31,23 @@ resource "aws_security_group" "ec2-processor-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }

--- a/terraform/rabbitmq/main.tf
+++ b/terraform/rabbitmq/main.tf
@@ -60,6 +60,23 @@ resource "aws_security_group" "ec2-socorrorabbitmq-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }

--- a/terraform/symbolapi/main.tf
+++ b/terraform/symbolapi/main.tf
@@ -39,6 +39,23 @@ resource "aws_security_group" "ec2-symbolapi-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }

--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -37,6 +37,23 @@ resource "aws_security_group" "ec-socorroweb-sg" {
             "0.0.0.0/0"
         ]
     }
+    # Consul (tcp and udp).
+    ingress {
+        from_port = 8300
+        to_port = 8302
+        protocol = "tcp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
+    ingress {
+        from_port = 8301
+        to_port = 8302
+        protocol = "udp"
+        cidr_blocks = [
+            "172.31.0.0/16"
+        ]
+    }
     lifecycle {
         create_before_destroy = true
     }


### PR DESCRIPTION
This PR adds the same same two ingress rules to all of the EC2-based roles (except `consul` which already had them, heh). These rules allow all of the nodes to communicate with the Consul raft freely.

`r?` @jdotpz @rhelmer 