### PR TITLE
set hostname before joining consul

### DIFF
--- a/puppet/modules/socorro/manifests/role/common.pp
+++ b/puppet/modules/socorro/manifests/role/common.pp
@@ -21,7 +21,8 @@ class socorro::role::common {
   $consul_hostname = hiera("${::environment}/consul_hostname")
   exec {
     'join_consul_cluster':
-      command => "/usr/bin/consul join ${consul_hostname}"
+      command => "/usr/bin/consul join ${consul_hostname}",
+      require => Exec['set-hostname']
   }
 
   $logging_hostname = hiera("${::environment}/logging_hostname")


### PR DESCRIPTION
Ensure that the hostname has been set prior to joining the Consul cluster (this addresses a minor irritation more than anything, heh).

We do need to address the issue of when (and how) to set the hostname in a more general way. @jdotpz suggested doing it during cloud-init which makes sense to me. In any case, this PR can be merged while we work on a better solution.

`r?` @jdotpz @rhelmer 