### PR TITLE
workaround bug 1170420 - ensure symbols cache dir exists, until this …

### DIFF
--- a/puppet/modules/socorro/manifests/role/processor.pp
+++ b/puppet/modules/socorro/manifests/role/processor.pp
@@ -3,11 +3,21 @@ class socorro::role::processor {
 
 include socorro::role::common
 
+  # FIXME - remove this when bug 1170420 is fixed in Socorro Processor
+  file {
+    '/tmp/symbols':
+      ensure => 'directory',
+      owner  => socorro
+  }
+
   service {
     'socorro-processor':
       ensure  => running,
       enable  => true,
-      require => Exec['join_consul_cluster'];
+      require => [
+        Exec['join_consul_cluster'],
+        File['/tmp/symbols']
+      ];
   }
 
 }


### PR DESCRIPTION
…is fixed in Socorro Processor

r? @jdotpz  