### PR TITLE
Add more instrumentation to datadog in elasticsearch / rabbitmq

### DIFF
--- a/puppet/modules/socorro/files/etc_dd-agent/elasticsearch.yaml
+++ b/puppet/modules/socorro/files/etc_dd-agent/elasticsearch.yaml
@@ -1,0 +1,22 @@
+init_config:
+
+instances:
+  # The URL where elasticsearch accepts HTTP requests. This will be used to
+  # fetch statistics from the nodes and information about the cluster health.
+  #
+  # If you're using basic authentication with a 3rd party library, for example
+  # elasticsearch-http-basic, you will need to specify a value for username
+  # and password for every instance that requires authentication.
+  #
+  # If your cluster is hosted externally (i.e., you're not pointing to localhost)
+  # you will need to set `is_external` to true otherwise the check will compare
+  # the local hostname against hostnames of the Elasticsearch nodes and only
+  # submit metrics if they match.
+  #
+  - url: http://localhost:9200
+    # username: username
+    # password: password
+    # is_external: false
+    # tags:
+    #   - 'tag1:key1'
+    #   - 'tag2:key2'

--- a/puppet/modules/socorro/files/etc_dd-agent/rabbitmq.yaml
+++ b/puppet/modules/socorro/files/etc_dd-agent/rabbitmq.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+    -  rabbitmq_api_url: http://localhost:15672/api/
+       rabbitmq_user: guest # defaults to 'guest'
+       rabbitmq_pass: guest # defaults to 'guest'

--- a/puppet/modules/socorro/manifests/role/elasticsearch.pp
+++ b/puppet/modules/socorro/manifests/role/elasticsearch.pp
@@ -75,4 +75,21 @@ include socorro::role::common
     }
   }
 
+if $::elasticsearch_role == 'interface'  {
+    file {
+    '/etc/dd-agent/conf.d/elasticsearch.yaml':
+      mode   => '0640',
+      owner  => 'dd-agent',
+      source => 'puppet:///modules/socorro/etc_dd-agent/elasticsearch.yaml',
+      notify => Service['datadog-agent']
+  }
+
+  service {
+    'datadog-agent':
+      ensure    => running,
+      enable    => true,
+      hasstatus => false,
+      pattern   => 'datadog-agent'
+  }
+}
 }

--- a/puppet/modules/socorro/manifests/role/rabbitmq.pp
+++ b/puppet/modules/socorro/manifests/role/rabbitmq.pp
@@ -10,4 +10,19 @@ include socorro::role::common
       require => Exec['join_consul_cluster'];
   }
 
+  file {
+    '/etc/dd-agent/conf.d/rabbitmq.yaml':
+      mode   => '0640',
+      owner  => 'dd-agent',
+      source => 'puppet:///modules/socorro/etc_dd-agent/rabbitmq.yaml',
+      notify => Service['datadog-agent']
+  }
+
+  service {
+    'datadog-agent':
+      ensure    => running,
+      enable    => true,
+      hasstatus => false,
+      pattern   => 'datadog-agent'
+  }
 }


### PR DESCRIPTION
## Knowing things is awesome!

Here we add elasticsearch and rabbitmq datadog agents.
Since we do an include, I believe we can double define resources (such as service['datadog-agent'])
