### PR TITLE
Fix instance deregistration

### DIFF
--- a/bin/deploy-socorro.sh
+++ b/bin/deploy-socorro.sh
@@ -253,6 +253,7 @@ function deregister_elb_nodes() {
     for ROLEENVNAME in $(cat /home/centos/socorro-infra/bin/lib/${ENVNAME}_socorro_master.list)
         do
         # Get ELB and AS group name.
+        identify_role ${ROLEENVNAME}
         if [ "${ELBNAME}" = "NONE" ];then
             echo "No ELB to check for ${ROLEENVNAME}"
             else

--- a/bin/lib/infra_status.sh
+++ b/bin/lib/infra_status.sh
@@ -27,13 +27,14 @@ function infra_report() {
         --auto-scaling-group-names ${AUTOSCALENAME} \
         --query 'AutoScalingGroups[*].[MinSize, DesiredCapacity, MaxSize]' \
         --output text
+
     ELBNAME=$(aws autoscaling describe-auto-scaling-groups \
               --auto-scaling-group-names ${AUTOSCALENAME} \
               --query 'AutoScalingGroups[*].LoadBalancerNames' \
               --output text)
     echo "=== ELB ENDPOINT ==="
     aws elb describe-load-balancers \
-        --load-balancer-name elb-stage-socorroweb \
+        --load-balancer-name ${ELBNAME} \
         --query 'LoadBalancerDescriptions[*].DNSName' \
         --output text
     echo "=== ELB HEALTH ==="


### PR DESCRIPTION
We were seeing this during ELB deregistration step:
 
Thu Jun  4 16:43:38 UTC 2015 -- Starting scale down
No ELB to check for socorroweb-prod
No ELB to check for collector-prod
No ELB to check for processor-prod
No ELB to check for socorroadmin-prod
Thu Jun  4 16:43:38 UTC 2015 -- All instances in ELBs deregistered, waiting for the 30 second drain period

This will fix that.