### PR TITLE
Cleanup which roleenvs get updates

### DIFF
--- a/bin/jenkins/backup_jenkins.sh
+++ b/bin/jenkins/backup_jenkins.sh
@@ -58,10 +58,10 @@ function wait_for_ami() {
     PROGSTEP="Waiting for AMI"
     echo "`date` -- Waiting 300 seconds for ${AMIID} to become available"
     sleep 300
-    until aws ec2 describe-images --image-id ${AMIID} --output text --query 'Images[*}.State'| grep available > /dev/null;
+    until aws ec2 describe-images --image-id ${AMIID} --output text | grep available > /dev/null
         do
         echo "`date` -- Waiting for ${AMIID} to become available"
-        sleep 30
+        sleep 60
     done
 }
 

--- a/bin/jenkins/update-infrastructure.sh
+++ b/bin/jenkins/update-infrastructure.sh
@@ -10,7 +10,6 @@ SCALEUPCOOLDOWN=300  # Seconds to wait before allowing further scale down adjust
 SCALEUPTHRESHOLD=70  # Avg CPU utilization of cluster before scale up
 SCALEDOWNTHRESHOLD=20  # Avg CPU utilization of cluster before scale down
 
-
 # Source functions in lib scripts
 . /home/centos/socorro-infra/bin/lib/identify_role.sh
 . /home/centos/.aws-config

--- a/bin/lib/infra_to_update.list
+++ b/bin/lib/infra_to_update.list
@@ -6,7 +6,6 @@ socorroadmin-stage
 symbolapi-stage
 consul-stage
 socorrorabbitmq-stage
-elasticsearch-stage
 socorrobuildbox-stage
 socorroweb-prod
 collector-prod
@@ -16,4 +15,3 @@ socorroadmin-prod
 symbolapi-prod
 consul-prod
 socorrorabbitmq-prod
-elasticsearch-prod

--- a/puppet/modules/socorro/manifests/role/elasticsearch.pp
+++ b/puppet/modules/socorro/manifests/role/elasticsearch.pp
@@ -75,6 +75,7 @@ include socorro::role::common
     }
   }
 
+# If this is an interface node, we want the datadog agent on it
 if $::elasticsearch_role == 'interface'  {
     file {
     '/etc/dd-agent/conf.d/elasticsearch.yaml':
@@ -83,13 +84,6 @@ if $::elasticsearch_role == 'interface'  {
       source => 'puppet:///modules/socorro/etc_dd-agent/elasticsearch.yaml',
       notify => Service['datadog-agent']
   }
-
-  service {
-    'datadog-agent':
-      ensure    => running,
-      enable    => true,
-      hasstatus => false,
-      pattern   => 'datadog-agent'
-  }
 }
+
 }

--- a/puppet/modules/socorro/manifests/role/rabbitmq.pp
+++ b/puppet/modules/socorro/manifests/role/rabbitmq.pp
@@ -15,14 +15,5 @@ include socorro::role::common
       mode   => '0640',
       owner  => 'dd-agent',
       source => 'puppet:///modules/socorro/etc_dd-agent/rabbitmq.yaml',
-      notify => Service['datadog-agent']
-  }
-
-  service {
-    'datadog-agent':
-      ensure    => running,
-      enable    => true,
-      hasstatus => false,
-      pattern   => 'datadog-agent'
   }
 }


### PR DESCRIPTION
This cleans up elasticsearch infra from the nodes we update with special settings (ie, elb alarms, etc, all from updateinfrastructure script).
It also fixes a bug in the Jenkins backup job.