### PR TITLE
fix bug 1172892; swap in emergencies only

### DIFF
--- a/puppet/modules/socorro/files/etc_sysctl.d/10-swappiness.conf
+++ b/puppet/modules/socorro/files/etc_sysctl.d/10-swappiness.conf
@@ -1,0 +1,3 @@
+# Swap in emergencies only.
+# https://www.elastic.co/guide/en/elasticsearch/reference/1.4/setup-configuration.html
+vm.swappiness = 1

--- a/puppet/modules/socorro/manifests/role/elasticsearch.pp
+++ b/puppet/modules/socorro/manifests/role/elasticsearch.pp
@@ -12,6 +12,15 @@ include socorro::role::common
       source => 'puppet:///modules/socorro/etc_security_limits.d/90-elasticsearch.conf'
   }
 
+  # Use swap in emergencies only.
+  file {
+    '/etc/sysctl.d/10-swappiness.conf':
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+      source => 'puppet:///modules/socorro/etc_sysctl.d/10-swappiness.conf'
+  }
+
   # These switches determine the role of the node: master, interface, or data.
   $es_master = $::elasticsearch_role ? {
     'master' => true,


### PR DESCRIPTION
The [ES docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html) state that swap should be disabled (or at least reduced) and suggest three ways to accomplish this goal. Of the three, I prefer using sysctl to adjust vm.swappiness since this is straightforward to do via Puppet.

@rhelmer @jdotpz `r?`