### PR TITLE
[bug 1173085] deal with ebs mount edge case

### DIFF
--- a/terraform/processor/main.tf
+++ b/terraform/processor/main.tf
@@ -71,9 +71,8 @@ resource "aws_launch_configuration" "lc-processor" {
     lifecycle {
         create_before_destroy = true
     }
-
     ephemeral_block_device {
-        device_name = "/dev/xvdc"
+        device_name = "/dev/xvdb"
         virtual_name = "ephemeral0"
     }
 }
@@ -94,18 +93,18 @@ resource "aws_autoscaling_group" "as-processor" {
     min_size = "${lookup(var.processor_num, var.environment)}"
     desired_capacity = "${lookup(var.processor_num, var.environment)}"
     tag {
-      key = "Environment"
-      value = "${var.environment}"
-      propagate_at_launch = true
+        key = "Environment"
+        value = "${var.environment}"
+        propagate_at_launch = true
     }
     tag {
-      key = "role"
-      value = "processor"
-      propagate_at_launch = true
+        key = "role"
+        value = "processor"
+        propagate_at_launch = true
     }
     tag {
-      key = "project"
-      value = "socorro"
-      propagate_at_launch = true
+        key = "project"
+        value = "socorro"
+        propagate_at_launch = true
     }
 }


### PR DESCRIPTION
Since cloud-init is a bit of an unknown for us right now, I reasoned that Puppet presented the most rapid path to dealing with the EBS mount [edge case](https://bugzilla.mozilla.org/show_bug.cgi?id=1173085).

I've tested this and, from a system perspective, it appears to work as expected. :grin:  In terms of actual deployment there are some configuration (Consul) elements that will need to be adjusted.  Let's open a dialogue on the best way to roll this out.

`r?` @rhelmer @jdotpz 