### PR TITLE
[bug 1153508] alternate LB for Collectors that uses an old, dangerous SSL config

### DIFF
--- a/terraform/collector/main.tf
+++ b/terraform/collector/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
 
 resource "aws_security_group" "ec2-collector-sg" {
     name = "ec2-collector-${var.environment}-sg"
-    description = "Security grup for ec2 as group for socorro collector."
+    description = "Security group for EC2 socorro collector."
     ingress {
         from_port = "${var.alt_ssh_port}"
         to_port = "${var.alt_ssh_port}"
@@ -90,11 +90,11 @@ resource "aws_elb" "elb-collector" {
         "${var.elb_master_web_sg_id}"
     ]
     health_check {
-      healthy_threshold = 2
-      unhealthy_threshold = 2
-      timeout = 3
-      target = "TCP:80"
-      interval = 12
+        healthy_threshold = 2
+        unhealthy_threshold = 2
+        timeout = 3
+        target = "TCP:80"
+        interval = 12
     }
     tags {
         Environment = "${var.environment}"
@@ -104,6 +104,53 @@ resource "aws_elb" "elb-collector" {
     cross_zone_load_balancing = true
     connection_draining = true
     connection_draining_timeout = 30
+}
+
+resource "aws_elb" "elb-collector-oldssl" {
+    name = "elb-${var.environment}-collector-oldssl"
+    availability_zones = [
+        "${var.region}a",
+        "${var.region}b",
+        "${var.region}c"
+    ]
+    listener {
+        instance_port = 80
+        instance_protocol = "http"
+        lb_port = 80
+        lb_protocol = "http"
+    }
+    listener {
+        instance_port = 80
+        instance_protocol = "http"
+        lb_port = 443
+        lb_protocol = "https"
+        ssl_certificate_id = "${var.collector_cert}"
+    }
+    security_groups = [
+        "${var.elb_master_web_sg_id}"
+    ]
+    health_check {
+        healthy_threshold = 2
+        unhealthy_threshold = 2
+        timeout = 3
+        target = "TCP:80"
+        interval = 12
+    }
+    tags {
+        Environment = "${var.environment}"
+        role = "collector"
+        project = "socorro"
+    }
+    cross_zone_load_balancing = true
+    connection_draining = true
+    connection_draining_timeout = 30
+    ### SSL policies aren't handled natively by TF, so here we go...
+    provisioner "local-exec" {
+        command = "aws elb create-load-balancer-policy --region ${var.region} --load-balancer-name ${aws_elb.elb-collector-oldssl.name} --policy-name oldssl --policy-type-name SSLNegotiationPolicyType --policy-attributes AttributeName=Reference-Security-Policy,AttributeValue=ELBSecurityPolicy-2011-08"
+    }
+    provisioner "local-exec" {
+        command = "aws elb set-load-balancer-policies-of-listener --region ${var.region} --load-balancer-name ${aws_elb.elb-collector-oldssl.name} --load-balancer-port 443 --policy-names oldssl"
+    }
 }
 
 resource "aws_launch_configuration" "lc-collector" {
@@ -137,21 +184,22 @@ resource "aws_autoscaling_group" "as-collector" {
     min_size = "${lookup(var.collector_num, var.environment)}"
     desired_capacity = "${lookup(var.collector_num, var.environment)}"
     load_balancers = [
-        "elb-${var.environment}-collector"
+        "elb-${var.environment}-collector",
+        "elb-${var.environment}-collector-oldssl"
     ]
     tag {
-      key = "Environment"
-      value = "${var.environment}"
-      propagate_at_launch = true
+        key = "Environment"
+        value = "${var.environment}"
+        propagate_at_launch = true
     }
     tag {
-      key = "role"
-      value = "collector"
-      propagate_at_launch = true
+        key = "role"
+        value = "collector"
+        propagate_at_launch = true
     }
     tag {
-      key = "project"
-      value = "socorro"
-      propagate_at_launch = true
+        key = "project"
+        value = "socorro"
+        propagate_at_launch = true
     }
 }

--- a/terraform/collector/outputs.tf
+++ b/terraform/collector/outputs.tf
@@ -1,3 +1,7 @@
 output "public_addr__collector__http" {
     value = "${aws_elb.elb-collector.dns_name}"
 }
+
+output "public_addr__collector__oldssl" {
+    value = "${aws_elb.elb-collector-oldssl.dns_name}"
+}


### PR DESCRIPTION
Using [cipherscan](https://github.com/jvehent/cipherscan) to check the endpoints; first the extant (modern) endpoint:
```
prio  ciphersuite                  protocols              pfs                 curves
1     ECDHE-RSA-AES128-GCM-SHA256  TLSv1.2                ECDH,P-256,256bits  prime256v1
2     ECDHE-RSA-AES128-SHA256      TLSv1.2                ECDH,P-256,256bits  prime256v1
3     ECDHE-RSA-AES128-SHA         TLSv1,TLSv1.1,TLSv1.2  ECDH,P-256,256bits  prime256v1
4     ECDHE-RSA-AES256-GCM-SHA384  TLSv1.2                ECDH,P-256,256bits  prime256v1
5     ECDHE-RSA-AES256-SHA384      TLSv1.2                ECDH,P-256,256bits  prime256v1
6     ECDHE-RSA-AES256-SHA         TLSv1,TLSv1.1,TLSv1.2  ECDH,P-256,256bits  prime256v1
7     AES128-GCM-SHA256            TLSv1.2                None                None
8     AES128-SHA256                TLSv1.2                None                None
9     AES128-SHA                   TLSv1,TLSv1.1,TLSv1.2  None                None
10    AES256-GCM-SHA384            TLSv1.2                None                None
11    AES256-SHA256                TLSv1.2                None                None
12    AES256-SHA                   TLSv1,TLSv1.1,TLSv1.2  None                None
13    DES-CBC3-SHA                 TLSv1,TLSv1.1,TLSv1.2  None                None

Certificate: trusted, 2048 bit, sha256WithRSAEncryption signature
TLS ticket lifetime hint: 300
OCSP stapling: not supported
Cipher ordering: server
```

Now the endpoint that's set set to use the ancient, crufty, hopefully-WinXP-compatible SSL policy:
```
prio  ciphersuite              protocols    pfs
1     DHE-RSA-AES256-SHA       SSLv3,TLSv1  DH,1024bits  None
2     DHE-RSA-CAMELLIA256-SHA  SSLv3,TLSv1  DH,1024bits  None
3     AES256-SHA               SSLv3,TLSv1  None         None
4     CAMELLIA256-SHA          SSLv3,TLSv1  None         None
5     DHE-RSA-AES128-SHA       SSLv3,TLSv1  DH,1024bits  None
6     DHE-RSA-CAMELLIA128-SHA  SSLv3,TLSv1  DH,1024bits  None
7     AES128-SHA               SSLv3,TLSv1  None         None
8     CAMELLIA128-SHA          SSLv3,TLSv1  None         None
9     RC4-SHA                  SSLv3,TLSv1  None         None
10    EDH-RSA-DES-CBC3-SHA     SSLv3,TLSv1  DH,1024bits  None
11    DES-CBC3-SHA             SSLv3,TLSv1  None         None

Certificate: trusted, 2048 bit, sha256WithRSAEncryption signature
TLS ticket lifetime hint: 300
OCSP stapling: not supported
Cipher ordering: client
```

So far so good, but it's possible (likely?) that a new cert will need to be generated that uses SHA1 instead of SHA256. Once that's in place, we can run the battery of compatibility tests (read: ping dmajor) against it. If it's insufficiently unsafe, we can always try to roll our own config.

`r?` @rhelmer @jdotpz for the TF config (we'll get OpSec involved if this looks reasonable).