### PR TITLE
[bug 1174099] tune ES for indexing operations

### DIFF
--- a/puppet/modules/socorro/files/etc_sysconfig/elasticsearch.erb
+++ b/puppet/modules/socorro/files/etc_sysconfig/elasticsearch.erb
@@ -3,7 +3,7 @@ ES_HOME=/usr/share/elasticsearch
 
 # Heap Size (defaults to 256m min, 1g max)
 <% if @es_master %>
-ES_HEAP_SIZE=15g
+ES_HEAP_SIZE=1.5g
 <% elsif @es_data %>
 ES_HEAP_SIZE=20g
 <% elsif @es_interface %>

--- a/puppet/modules/socorro/templates/etc_elasticsearch/elasticsearch.yml.erb
+++ b/puppet/modules/socorro/templates/etc_elasticsearch/elasticsearch.yml.erb
@@ -12,6 +12,13 @@ discovery:
             role: "elasticsearch"
 index:
     number_of_replicas: 1
+    refresh_interval: "30s"
+indices:
+    memory:
+        index_buffer_size: "30%"
+    store:
+        throttle:
+            max_bytes_per_sec: "100mb"
 action:
     disable_shutdown: true
     disable_delete_all_indices: true


### PR DESCRIPTION
A handful of tweaks to improve indexing performance.

I decided not to play with the threads - this was standard practice back in the 0.90 era, but appears to be [frowned upon](https://www.elastic.co/guide/en/elasticsearch/guide/current/_don_8217_t_touch_these_settings.html#_threadpools) now.

`r?` @rhelmer @erikrose 