### PR TITLE
launch config roles should not attempt package upgrades

### DIFF
--- a/puppet/modules/socorro/manifests/role/collector.pp
+++ b/puppet/modules/socorro/manifests/role/collector.pp
@@ -7,7 +7,6 @@ include socorro::role::common
     'nginx':
       ensure    => running,
       enable    => true,
-      require   => Package['nginx'],
       subscribe => File['/etc/nginx/conf.d/socorro-collector.conf'];
 
     'socorro-collector':
@@ -19,7 +18,6 @@ include socorro::role::common
       ensure  => running,
       enable  => true,
       require => [
-        Package['socorro'],
         Exec['join_consul_cluster']
       ];
   }
@@ -29,8 +27,7 @@ include socorro::role::common
       source  => 'puppet:///modules/socorro/etc_nginx/nginx.conf',
       owner   => 'root',
       group   => 'root',
-      mode    => '0664',
-      require => Package['nginx'];
+      mode    => '0664';
 
     '/etc/nginx/conf.d/socorro-collector.conf':
       source  => 'puppet:///modules/socorro/etc_nginx/conf_d/socorro-collector.conf',
@@ -38,14 +35,6 @@ include socorro::role::common
       group   => 'root',
       mode    => '0664',
       require => File['/etc/nginx/nginx.conf'];
-  }
-
-  package {
-    [
-      'nginx',
-      'socorro'
-    ]:
-    ensure => latest
   }
 
 }

--- a/puppet/modules/socorro/manifests/role/webapp.pp
+++ b/puppet/modules/socorro/manifests/role/webapp.pp
@@ -7,7 +7,6 @@ include socorro::role::common
     'nginx':
       ensure    => running,
       enable    => true,
-      require   => Package['nginx'],
       subscribe => File[
         '/etc/nginx/conf.d/socorro-webapp.conf',
         '/etc/nginx/conf.d/socorro-middleware.conf'
@@ -22,7 +21,6 @@ include socorro::role::common
       ensure  => running,
       enable  => true,
       require => [
-        Package['socorro'],
         Exec['join_consul_cluster']
       ];
   }
@@ -32,8 +30,7 @@ include socorro::role::common
       source  => 'puppet:///modules/socorro/etc_nginx/nginx.conf',
       owner   => 'root',
       group   => 'root',
-      mode    => '0664',
-      require => Package['nginx'];
+      mode    => '0664';
 
     '/etc/nginx/conf.d/socorro-webapp.conf':
       source  => 'puppet:///modules/socorro/etc_nginx/conf_d/socorro-webapp.conf',
@@ -48,14 +45,6 @@ include socorro::role::common
       group   => 'nginx',
       mode    => '0664',
       require => File['/etc/nginx/nginx.conf'];
-  }
-
-  package {
-    [
-      'nginx',
-      'socorro'
-    ]:
-    ensure => latest
   }
 
 }


### PR DESCRIPTION
r? @jdotpz - we want these packages to be baked into the AMI, and not modified at launch time. In particular, the Socorro package doesn't always upgrade cleanly so could cause problems (that's how I noticed this, on the webapp :) )