### PR TITLE
Adjust elb timeout

### DIFF
--- a/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-collector.conf
+++ b/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-collector.conf
@@ -11,6 +11,7 @@ server {
 
     location / {
         uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-collector.sock;
+        uwsgi_read_timeout 300s;
         include uwsgi_params;
     }
 }

--- a/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
+++ b/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
@@ -11,6 +11,7 @@ server {
 
     location / {
         uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-webapp.sock;
+        uwsgi_read_timeout 300s;
         include uwsgi_params;
     }
 

--- a/terraform/collector/main.tf
+++ b/terraform/collector/main.tf
@@ -104,7 +104,7 @@ resource "aws_elb" "elb-collector" {
     cross_zone_load_balancing = true
     connection_draining = true
     connection_draining_timeout = 30
-    # give extra time for symbol uploads
+    # give extra time for crash reports
     idle_timeout = 300
 }
 

--- a/terraform/webapp/main.tf
+++ b/terraform/webapp/main.tf
@@ -157,6 +157,8 @@ resource "aws_elb" "elb-socorroweb" {
     cross_zone_load_balancing = true
     connection_draining = true
     connection_draining_timeout = 30
+    # give extra time for symbol uploads
+    idle_timeout = 300
 }
 
 resource "aws_launch_configuration" "lc-socorroweb" {


### PR DESCRIPTION
r? @phrawzty / @jdotpz - sorry, re-reading the bug, I missed a few things:

* both collector and webapp ELBs should have 5 minute timeout (from default 60s)
* nginx idle timeout should be 5 minutes (default is 60s as well)