### PR TITLE
Loggly

### DIFF
--- a/puppet/modules/socorro/files/etc_rsyslog/30-socorro.conf
+++ b/puppet/modules/socorro/files/etc_rsyslog/30-socorro.conf
@@ -1,0 +1,16 @@
+#Setup disk assisted queues
+$WorkDirectory /var/spool/rsyslog # where to place spool files
+$ActionQueueFileName fwdRule1     # unique name prefix for spool files
+$ActionQueueMaxDiskSpace 1g       # 1gb space limit (use as much as possible)
+$ActionQueueSaveOnShutdown on     # save messages to disk on shutdown
+$ActionQueueType LinkedList       # run asynchronously
+$ActionResumeRetryCount -1        # infinite retries if host is down
+
+template(name="LogglyFormat" type="string"
+ string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [b003f28a-5fdc-46d6-ae23-4109ffc80c54@41058 tag=\"socorro\"] %msg%\n")
+
+# Send messages to Loggly over TCP using the template.
+action(type="omfwd" protocol="tcp" target="logs-01.loggly.com" port="514" template="LogglyFormat")
+
+
+

--- a/puppet/modules/socorro/manifests/role/common.pp
+++ b/puppet/modules/socorro/manifests/role/common.pp
@@ -25,15 +25,23 @@ class socorro::role::common {
       require => Exec['set-hostname']
   }
 
-  $logging_hostname = hiera("${::environment}/logging_hostname")
+  #  $logging_hostname = hiera("${::environment}/logging_hostname")
   file {
     '/etc/rsyslog.d/30-socorro.conf':
-      content => template('socorro/etc_rsyslog.d/30-socorro.conf.erb'),
+      source  => 'puppet:///modules/socorro/etc_rsyslog/30-socorro.conf',
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
       notify  => Service['rsyslog'],
       require => Exec['set-hostname']
+  }
+
+
+  file {
+    '/etc/dd-agent/conf.d/rabbitmq.yaml':
+      mode   => '0640',
+      owner  => 'dd-agent',
+      source => 'puppet:///modules/socorro/etc_dd-agent/rabbitmq.yaml',
   }
 
   service {


### PR DESCRIPTION
Temporarily move from using a template to a file because the loggly format breaks puppet.

Jul 28 17:02:54 ip-172-31-4-34 cloud-init: Error: Failed to parse template socorro/etc_rsyslog.d/30-socorro.conf.erb:
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: Filepath: /usr/share/ruby/vendor_ruby/puppet/parser/templatewrapper.rb
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: Line: 82
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: Detail: Could not find value for 'pri' at /etc/puppet/module-0/socorro/templates/etc_rsyslog.d/30-socorro.conf.erb:10
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: at /etc/puppet/module-0/socorro/manifests/role/common.pp:31 on node ip-172-31-30-139.us-west-2.compute.internal
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: Error: Failed to parse template socorro/etc_rsyslog.d/30-socorro.conf.erb:
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: Filepath: /usr/share/ruby/vendor_ruby/puppet/parser/templatewrapper.rb
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: Line: 82
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: Detail: Could not find value for 'pri' at /etc/puppet/module-0/socorro/templates/etc_rsyslog.d/30-socorro.conf.erb:10
Jul 28 17:02:54 ip-172-31-4-34 cloud-init: at /etc/puppet/module-0/socorro/manifests/role/common.pp:31 on node ip-172-31-30-139.us-west-2.compute.internal