### PR TITLE
Restart rsyslog after applying hostname

### DIFF
--- a/terraform/socorro_role.sh
+++ b/terraform/socorro_role.sh
@@ -28,6 +28,7 @@ function socorro_role {
     NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
     /bin/echo ${NEWHOSTNAME} > /etc/hostname
     /bin/hostname -F /etc/hostname
+    service restart rsyslog
 }
 
 # Required variables will be inserted by Terraform.


### PR DESCRIPTION
Noticed some of the hosts didn't start reporting as the new hostname until i manually restarted rsyslog.