### PR TITLE
Fix missing hostname updates in most roles

### DIFF
--- a/terraform/analysis/socorro_role.sh
+++ b/terraform/analysis/socorro_role.sh
@@ -19,7 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
+
 
 # Required variables will be inserted by Terraform.
 socorro_role \

--- a/terraform/buildbox/socorro_role.sh
+++ b/terraform/buildbox/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/collector/socorro_role.sh
+++ b/terraform/collector/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/consul/socorro_role.sh
+++ b/terraform/consul/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/elasticsearch/socorro_role.sh
+++ b/terraform/elasticsearch/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/postgres/socorro_role.sh
+++ b/terraform/postgres/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/processor/socorro_role.sh
+++ b/terraform/processor/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/rabbitmq/socorro_role.sh
+++ b/terraform/rabbitmq/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/symbolapi/socorro_role.sh
+++ b/terraform/symbolapi/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.

--- a/terraform/webapp/socorro_role.sh
+++ b/terraform/webapp/socorro_role.sh
@@ -19,6 +19,16 @@ function socorro_role {
     puppet apply \
     --modulepath=${DIR}/module-0:/etc/puppet/modules \
     ${DIR}/manifests/default.pp
+
+    # Set hostname of $env-$role-instanceid
+    # We'll get the instance id from ec2metadta
+    INSTANCEID=$(/bin/ec2-metadata | grep instance-id | \
+                 awk '{print $2}' | \
+                 head -n1 )
+    NEWHOSTNAME=${ENV}-${ROLE}-${INSTANCEID}
+    /bin/echo ${NEWHOSTNAME} > /etc/hostname
+    /bin/hostname -F /etc/hostname
+    /usr/sbin/service rsyslog restart
 }
 
 # Required variables will be inserted by Terraform.


### PR DESCRIPTION
When we added socorro_role.sh into each existing folder instead of symlinking, we lost our fancy new hostnames.