### PR TITLE
fixes bug 1196344 - Correctly cache static assets

### DIFF
--- a/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
+++ b/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
@@ -11,9 +11,18 @@ server {
     # crash-stats needs to accept debug symbol zips
     client_max_body_size 1g;
 
+    # all URLs under this prefix will have unique URLs
     location /static/CACHE {
         add_header   Cache-Control public;
         expires      max;
+        access_log   off;
+        break;
+    }
+
+    # files like /static/browserid.js that don't have a unique URL
+    location /static {
+        add_header   Cache-Control public;
+        expires      1d;
         access_log   off;
         break;
     }

--- a/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
+++ b/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
@@ -2,6 +2,8 @@ server {
     listen 80 default_server;
     server_name crash-stats;
 
+    root /data/socorro/webapp-django;
+
     if ($http_x_forwarded_proto != 'https') {
         rewrite ^(.*) https://$host$1 permanent;
     }
@@ -9,13 +11,21 @@ server {
     # crash-stats needs to accept debug symbol zips
     client_max_body_size 1g;
 
-    location / {
+    location /static/CACHE {
+        add_header   Cache-Control public;
+        expires      max;
+        access_log   off;
+        break;
+    }
+
+    # This will try to serve the file as a static asset if
+    # the file exists. If not it proceeds to let Django deal with it.
+    try_files $uri @proxy;
+
+    location @proxy {
         uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-webapp.sock;
         uwsgi_read_timeout 300s;
         include uwsgi_params;
     }
 
-    location /static {
-        alias /data/socorro/webapp-django/static/;
-    }
 }


### PR DESCRIPTION
@jdotpz r?

I'm not familiar with the `alias` command in nginx but I guess it's like a rewrite. Instead it's better to just set the root and any URL that can't be mapped to a file on the file system gets sent as a request to Django. 

This is the set up I have on my personal server. 