### PR TITLE
Revert "Fixes bug 1212485, forces crash dir to be owned properly"

### DIFF
--- a/puppet/modules/socorro/manifests/packer/base.pp
+++ b/puppet/modules/socorro/manifests/packer/base.pp
@@ -122,17 +122,6 @@ class socorro::packer::base {
       owner   => 'root',
       require => Package['elasticsearch'],
       notify  => Service['elasticsearch'];
-
-    '/home/socorro':
-      ensure => directory,
-      owner  => 'socorro',
-      group  => 'nginx';
-
-    '/home/socorro/crashes':
-      ensure  => directory,
-      owner   => 'socorro',
-      group   => 'nginx',
-      require => File['/home/socorro'];
   }
 
 


### PR DESCRIPTION
Reverts mozilla/socorro-infra#215