### PR TITLE
longer caching for /static URLS

### DIFF
--- a/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
+++ b/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
@@ -31,18 +31,10 @@ server {
     # crash-stats needs to accept debug symbol zips
     client_max_body_size 1g;
 
-    # all URLs under this prefix will have unique URLs
-    location /static/CACHE {
-        add_header   Cache-Control public;
-        expires      max;
-        access_log   off;
-        break;
-    }
-
     # files like /static/browserid.js that don't have a unique URL
     location /static {
         add_header   Cache-Control public;
-        expires      1d;
+        expires      1y;
         access_log   off;
         break;
     }


### PR DESCRIPTION
We no longer need special caching for things under /static/CACHE since
we now use django-pipeline.
And for everything under /static we always have a unique hash in the URL.