### PR TITLE
fixes bug 1138570 - serve /favicon.ico directly from nginx

### DIFF
--- a/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
+++ b/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
@@ -43,6 +43,16 @@ server {
     # crash-stats needs to accept debug symbol zips
     client_max_body_size 1g;
 
+    # Browser convention is to seek this in the root but that's
+    # not where the file is.
+    location = /favicon.ico {
+        rewrite (.*) /crashstats/base/static/img$1;
+        add_header   Cache-Control public;
+        expires      1y;
+        access_log   off;
+        break;
+    }
+
     # files like /static/browserid.js that don't have a unique URL
     location /static {
         add_header   Cache-Control public;


### PR DESCRIPTION
I tested this by SSH'ing into the stage webhead and vi'ed the file and restarted nginx. 

This is what it looked like BEFORE:
```
:~/dev/MOZILLA/SOCORRO/socorro/webapp-django (master $%=)$ c https://crash-stats.allizom.org/favicon.ico
+ curl -v https://crash-stats.allizom.org/favicon.ico
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 54.186.216.236...
* Connected to crash-stats.allizom.org (54.186.216.236) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate: crash-stats.allizom.org
* Server certificate: DigiCert SHA2 Secure Server CA
* Server certificate: DigiCert Global Root CA
> GET /favicon.ico HTTP/1.1
> Host: crash-stats.allizom.org
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: image/vnd.microsoft.icon
< Date: Thu, 31 Mar 2016 13:58:06 GMT
< Last-Modified: Thu, 31 Mar 2016 10:55:11 GMT
< Server: nginx/1.6.3
< Set-Cookie: anoncsrf=5lliClz4MJg5yTSBoknYQberlGog8Ip7; expires=Thu, 31-Mar-2016 15:58:06 GMT; httponly; Max-Age=7200; Path=/; secure
< Vary: Cookie
< X-Frame-Options: DENY
< Content-Length: 1150
< Connection: keep-alive
<
{ [1150 bytes data]
100  1150  100  1150    0     0   1202      0 --:--:-- --:--:-- --:--:--  1201
* Connection #0 to host crash-stats.allizom.org left intact
```
Note how it sets a cookie (from django) and it has no cache control. 

After editing `/etc/nginx/conf.d/socorro-webapp.conf` and restarting, the same GET looks like this:

```
:~/dev/MOZILLA/SOCORRO/socorro/webapp-django (master $%=)$ c https://crash-stats.allizom.org/favicon.ico
+ curl -v https://crash-stats.allizom.org/favicon.ico
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 54.186.216.236...
* Connected to crash-stats.allizom.org (54.186.216.236) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate: crash-stats.allizom.org
* Server certificate: DigiCert SHA2 Secure Server CA
* Server certificate: DigiCert Global Root CA
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0> GET /favicon.ico HTTP/1.1
> Host: crash-stats.allizom.org
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Cache-Control: max-age=31536000
< Cache-Control: public
< Content-Type: image/x-icon
< Date: Thu, 31 Mar 2016 14:02:42 GMT
< ETag: "56fd020f-47e"
< Expires: Fri, 31 Mar 2017 14:02:42 GMT
< Last-Modified: Thu, 31 Mar 2016 10:55:11 GMT
< Server: nginx/1.6.3
< Content-Length: 1150
< Connection: keep-alive
<
{ [1150 bytes data]
100  1150  100  1150    0     0   1285      0 --:--:-- --:--:-- --:--:--  1284
* Connection #0 to host crash-stats.allizom.org left intact
```

No cookie. Proper Cache-Control. More correct Content-Type. 

The file isn't request super often (because many of our visitors have browser cache) but every little thing to make django do less is a win. 