### PR TITLE
[WIP DO NOT MERGE] Cleanup leftover volumes on each deploy

### DIFF
--- a/bin/deploy-socorro.sh
+++ b/bin/deploy-socorro.sh
@@ -341,6 +341,13 @@ function terminate_instances_all() {
         do
         terminate_instances $doomedinstances
     done
+    # We are junking old kit, so we should ditch all the unused volumes the scale out leaves behind
+    echo "`date` -- Removing old volumes"
+    aws ec2 describe-volumes –filters "Name=status,Values=available" "Name=size,Values=8" \
+                 --region us-west-2 --output json | \
+                 python -c "from __future__ import print_function; import json,sys;data=json.load(sys.stdin); [ print(v['VolumeId']) for v in data['Volumes']]" | \
+                 xargs -n 1 -I % aws ec2 delete-volume –volume-id=% --region us-west-2
+                    RETURNCODE=$?;echo "Finished removing old volumes with a ${RETURNCODE} return code"
 }
 
 function query_end_scale() {


### PR DESCRIPTION
We've had a few instances where we hit our volume limits, so I propose that each time we do a deploy, we clean those up.

We had this discussion previously, and balked at the idea because we had a lot more we were doing in terms of making test servers.

My calculation is that any volumes we have that people care about have sat there unused for a year.  If we haven't needed it by now, it's hard to see why we would later.  The script will only kill unused volumes which are 8gb in size.  Servers like analysis whose volumes we may one day want to detach and move or copy are sized differently.  

@phrawzty @willkg at your convenience, would love your thoughts.