### PR TITLE
Further lock down ES SG for 9300

### DIFF
--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -56,8 +56,8 @@ resource "aws_security_group" "ec2-socorroes-sg" {
         from_port = 9300
         to_port = 9300
         protocol = "tcp"
-        cidr_blocks = [
-            "172.31.0.0/16"
+        security_groups = [
+            "${aws_security_group.ec2-socorroes-sg.id}"
         ]
     }
     ingress {


### PR DESCRIPTION
addressing https://bugzilla.mozilla.org/show_bug.cgi?id=1184706

This is a rebase of https://github.com/mozilla/socorro-infra/pull/186 to trigger a new travis build and see if it plays nice.