### PR TITLE
webapp: fix ELB health check by using nginx to set HTTP_HOST

### DIFF
--- a/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
+++ b/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
@@ -72,6 +72,14 @@ server {
     proxy_redirect off;
     proxy_http_version 1.1;
 
+    location /monitoring/healthcheck/ {
+        # sets HTTP_HOST for AWS ELB Health Check
+        uwsgi_param HTTP_HOST 'crash-stats.allizom.org';
+        uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-webapp.sock;
+        uwsgi_read_timeout 300s;
+        include uwsgi_params;
+    }
+
     location @proxy {
         uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-webapp.sock;
         uwsgi_read_timeout 300s;

--- a/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
+++ b/puppet/modules/socorro/files/etc_nginx/conf_d/socorro-webapp.conf
@@ -1,6 +1,6 @@
 server {
     # redirect 80 -> 443
-    listen 80;
+    listen 80 default_server;
 
     location / {
         return 301 https://$host$request_uri;
@@ -8,7 +8,7 @@ server {
 }
 
 server {
-    listen 443 default;
+    listen 443 default_server;
     server_name crash-stats;
 
     root /data/socorro/webapp-django;

--- a/puppet/modules/socorro/files/etc_nginx/nginx.conf
+++ b/puppet/modules/socorro/files/etc_nginx/nginx.conf
@@ -21,7 +21,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$host" "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 

--- a/puppet/modules/socorro/manifests/role/webapp.pp
+++ b/puppet/modules/socorro/manifests/role/webapp.pp
@@ -5,6 +5,7 @@ include socorro::role::common
 
   $newrelic_app = hiera("${::environment}/newrelic_app")
   $newrelic_apikey = hiera("${::environment}/newrelic_apikey")
+  $crashstats_hostname = hiera("${::environment}/crashstats_hostname")
 
   service {
     'nginx':
@@ -49,7 +50,7 @@ include socorro::role::common
       require => File['/etc/newrelic'];
 
     '/etc/nginx/conf.d/socorro-webapp.conf':
-      source  => 'puppet:///modules/socorro/etc_nginx/conf_d/socorro-webapp.conf',
+      content => template('socorro/etc_nginx/conf_d/socorro-webapp.conf.erb'),
       owner   => 'root',
       group   => 'nginx',
       mode    => '0664',

--- a/puppet/modules/socorro/templates/etc_nginx/conf_d/socorro-webapp.conf.erb
+++ b/puppet/modules/socorro/templates/etc_nginx/conf_d/socorro-webapp.conf.erb
@@ -74,7 +74,7 @@ server {
 
     location /monitoring/healthcheck/ {
         # sets HTTP_HOST for AWS ELB Health Check
-        uwsgi_param HTTP_HOST 'crash-stats.allizom.org';
+        uwsgi_param HTTP_HOST <%= @crashstats_hostname %>;
         uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-webapp.sock;
         uwsgi_read_timeout 300s;
         include uwsgi_params;


### PR DESCRIPTION
@relud r?

The issue here is that uwsgi / django were not properly allowing a connection to the health check endpoint when HTTP_HOST was something other than expected. This caused local curls (host localhost) and AWS ELB Health Checks (host the IP of the instance) to fail.