### PR TITLE
remove stage-submitter from stage_socorro_master.list, add it to roles in wrapper.sh

### DIFF
--- a/bin/lib/identify_role.sh
+++ b/bin/lib/identify_role.sh
@@ -31,7 +31,7 @@ function identify_role() {
             SCALEVARIABLE="processor_num.stage"
             ;;
 
-        submitter-stage )
+        stage-submitter )
             AUTOSCALENAME="as-stage-submitter"
             ELBNAME="elb-stage-socorroweb"
             TERRAFORMNAME="stagesubmitter"

--- a/bin/lib/stage_socorro_master.list
+++ b/bin/lib/stage_socorro_master.list
@@ -1,4 +1,3 @@
 socorroweb-stage
 collector-stage
 processor-stage
-stage-submitter

--- a/terraform/wrapper.sh
+++ b/terraform/wrapper.sh
@@ -2,7 +2,7 @@
 # This script acts as a wrapper to Terraform.
 
 TFVARS="terraform.tfvars"
-ROLES=(admin analysis buildbox collector consul elasticsearch postgres processor rabbitmq symbolapi webapp)
+ROLES=(admin analysis buildbox collector consul elasticsearch postgres processor rabbitmq stagesubmitter symbolapi webapp)
 HELPARGS=("help" "-help" "--help" "-h" "-?")
 
 function help {


### PR DESCRIPTION
These changes were unmerged sitting on the buildbox. I figured I would preserve them.

The implications, best as I can tell:
Removing stage-submitter from stage_socorro_master.list means that stage-submitter will no longer be touched by deploy-socorro.sh. It is my impression that this was already the case, because in identify_role.sh it was listed as "submitter-stage" and not "stage-submitter". This is bizarre, the effect being that stage-submitter was _probably_ not touched. The last time the instance was modified was Oct 13th, 2016, which implies that it probably _was_ touched.

Ignoring this.

@lonnen @willkg @peterbe thoughts? I don't know much about the stage-submitter.