### PR TITLE
text/html from gzip config in webapp nginx

### DIFF
--- a/puppet/modules/socorro/templates/etc_nginx/conf_d/socorro-webapp.conf.erb
+++ b/puppet/modules/socorro/templates/etc_nginx/conf_d/socorro-webapp.conf.erb
@@ -21,7 +21,6 @@ server {
     gzip_buffers       16 8k; # because we have large javascript files
     gzip_types
         text/plain
-        text/html
         text/css
         application/json
         application/x-javascript


### PR DESCRIPTION
@relud r?

Turns out text/html is implicit and declaring it is a duplicate