### PR TITLE
Bug 1358577: Reverse order of crashmover crashstorage classes

### DIFF
--- a/socorro-config/crashmover.conf
+++ b/socorro-config/crashmover.conf
@@ -1,9 +1,9 @@
 destination.crashstorage_class=socorro.external.crashstorage_base.PolyCrashStorage
-destination.storage_classes=socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage, socorro.external.boto.crashstorage.BotoS3CrashStorage
-destination.storage0.crashstorage_class=socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage
-destination.storage1.benchmark_tag=S3BenchmarkWrite
-destination.storage1.crashstorage_class=socorro.external.crashstorage_base.BenchmarkingCrashStorage
-destination.storage1.wrapped_crashstore=socorro.external.boto.crashstorage.BotoS3CrashStorage
+destination.storage_classes=socorro.external.boto.crashstorage.BotoS3CrashStorage, socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage
+destination.storage0.benchmark_tag=S3BenchmarkWrite
+destination.storage0.crashstorage_class=socorro.external.crashstorage_base.BenchmarkingCrashStorage
+destination.storage0.wrapped_crashstore=socorro.external.boto.crashstorage.BotoS3CrashStorage
+destination.storage1.crashstorage_class=socorro.external.rabbitmq.crashstorage.RabbitMQCrashStorage
 producer_consumer.maximum_queue_size=24
 producer_consumer.number_of_threads=12
 source.crashstorage_class=socorro.external.fs.crashstorage.FSTemporaryStorage


### PR DESCRIPTION
It's better to have the BotoS3CrashStorage *before* the RabbitMQCrashStorage so
as to reduce the race condition where the processor goes to process a crash that
isn't on S3, yet.

This switches the order of `destination.storage_classes` and then swaps the `storage0` and `storage1` configurations.