### PR TITLE
Remove collector from list of services to deploy

### DIFF
--- a/bin/lib/prod_socorro_master.list
+++ b/bin/lib/prod_socorro_master.list
@@ -1,3 +1,2 @@
 socorroweb-prod
-collector-prod
 processor-prod

--- a/bin/lib/stage_socorro_master.list
+++ b/bin/lib/stage_socorro_master.list
@@ -1,3 +1,2 @@
 socorroweb-stage
-collector-stage
 processor-stage


### PR DESCRIPTION
These files are read into ROLES and then used in bin/lib/deploy_functions.sh to deploy the individual pieces of infra. Removing these lines should be all that is needed to stop deploying the collector.

@relud r?
@willkg 🎆