### PR TITLE
Make HTTP redirect use servername

### DIFF
--- a/puppet/modules/socorro/templates/etc_nginx/conf_d/socorro-webapp.conf.erb
+++ b/puppet/modules/socorro/templates/etc_nginx/conf_d/socorro-webapp.conf.erb
@@ -1,9 +1,9 @@
 server {
     # redirect 80 -> 443
     listen 80 default_server;
-
+i   server_name crash-stats;
     location / {
-        return 301 https://$host$request_uri;
+        return 301 https://$server_name$request_uri;
     }
 }
 

--- a/puppet/modules/socorro/templates/etc_nginx/conf_d/socorro-webapp.conf.erb
+++ b/puppet/modules/socorro/templates/etc_nginx/conf_d/socorro-webapp.conf.erb
@@ -1,7 +1,7 @@
 server {
     # redirect 80 -> 443
     listen 80 default_server;
-i   server_name crash-stats;
+    server_name crash-stats;
     location / {
         return 301 https://$server_name$request_uri;
     }


### PR DESCRIPTION
This simply sets the servername and uses it in it's redirect behavior.

Please verify this change, as I did not test it.