### PR TITLE
socorro-infra: use 8.x cloudops nodesource

### DIFF
--- a/puppet/modules/socorro/manifests/packer/base.pp
+++ b/puppet/modules/socorro/manifests/packer/base.pp
@@ -40,7 +40,7 @@ class socorro::packer::base {
     'datadog-agent':
       baseurl => 'http://yum.datadoghq.com/rpm/x86_64/';
     'nodesource':
-      baseurl => 'https://s3-us-west-2.amazonaws.com/net-mozaws-prod-us-west-2-ops-rpmrepo-mirror/nodesource/6.x/7/x86_64/',
+      baseurl => 'https://s3-us-west-2.amazonaws.com/net-mozaws-prod-us-west-2-ops-rpmrepo-mirror/nodesource/8.x/7/x86_64/',
       failovermethod => 'priority',
       enabled => 1,
       gpgcheck => 1,


### PR DESCRIPTION
self-r+ for now.