### PR TITLE
packer: delete volumes on termination

### DIFF
--- a/packer/socorro_base.json
+++ b/packer/socorro_base.json
@@ -13,7 +13,11 @@
             "source_ami": "ami-6935e909",
             "instance_type": "m3.medium",
             "ssh_username": "centos",
-            "ami_name": "socorro_centos7__{{timestamp}}"
+            "ami_name": "socorro_centos7__{{timestamp}}",
+            "launch_block_device_mappings": [{
+                "device_name": "/dev/sda1",
+                "delete_on_termination": true
+            }]
         }
     ],
     "provisioners": [


### PR DESCRIPTION
I should have done this so so so long ago.
See notes here: https://www.packer.io/docs/builders/amazon-ebs.html#ami_block_device_mappings
Basically, this is the cause of our volume woes: https://bugzilla.mozilla.org/show_bug.cgi?id=1298049